### PR TITLE
CST-74 fix: OAuth2 로그인 성공 시 토큰 전달 방식을 쿠키로 변경

### DIFF
--- a/src/main/java/com/graduationCapstone/Probe/global/security/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/security/jwt/filter/JwtFilter.java
@@ -25,9 +25,11 @@ public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtTokenProvider;
     private final UserRepository userRepository;
+    private final CookieUtil cookieUtil;
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
+    private static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain)
@@ -46,7 +48,6 @@ public class JwtFilter extends OncePerRequestFilter {
             User user = userRepository.findByIdAndDeletedFalse(userId).orElse(null);
 
             if (user != null) {
-
                 UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
                         user,
                         null, // 비밀번호 필요 없음
@@ -54,7 +55,6 @@ public class JwtFilter extends OncePerRequestFilter {
                 );
 
                 authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
         }
@@ -69,6 +69,16 @@ public class JwtFilter extends OncePerRequestFilter {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
         if (bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)) {
             return bearerToken.substring(BEARER_PREFIX.length());
+        }
+
+        // 헤더에 없다면 쿠키에서 추출 시도
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (ACCESS_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
         }
         return null;
     }

--- a/src/main/java/com/graduationCapstone/Probe/global/security/oauth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/security/oauth/handler/OAuth2LoginSuccessHandler.java
@@ -43,17 +43,12 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         String accessToken = jwtUtil.createAccessToken(user.getId());
         String refreshToken = jwtUtil.createRefreshToken(user.getId());
 
-        refreshTokenService.saveOrUpdate(
-                new RefreshTokenSaveDto(
-                        user.getId(),
-                        refreshToken
-                )
-        );
-
+        refreshTokenService.saveOrUpdate(new RefreshTokenSaveDto(user.getId(), refreshToken));
         cookieUtil.addRefreshCookie(response, refreshToken);
 
+        cookieUtil.addAccessCookie(response, accessToken);
+
         String targetUrl = UriComponentsBuilder.fromUriString(FRONTEND_REDIRECT_URL)
-                .queryParam("accessToken", accessToken)
                 .build().toUriString();
 
         getRedirectStrategy().sendRedirect(request, response, targetUrl);

--- a/src/main/java/com/graduationCapstone/Probe/global/security/util/CookieUtil.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/security/util/CookieUtil.java
@@ -12,7 +12,11 @@ public class CookieUtil {
     @Value("${jwt.refresh-token-expiration-days}")
     private long refreshTokenExpirationDays;
 
+    @Value("${jwt.access-token-expiration-minutes}")
+    private long accessTokenExpirationMinutes;
+
     public static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
+    public static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
 
 
     // Refresh Token 쿠키 생성
@@ -53,5 +57,15 @@ public class CookieUtil {
             }
         }
         return null;
+    }
+
+    // Access Token 쿠키 생성
+    public void addAccessCookie(HttpServletResponse response, String accessToken) {
+        Cookie cookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, accessToken);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false);  // 로컬 개발 환경이므로 false, 배포시 true 설정하여 HTTPS 환경에서만 쿠키가 전송되도록
+        cookie.setPath("/");
+        cookie.setMaxAge((int) (accessTokenExpirationMinutes * 60));
+        response.addCookie(cookie);
     }
 }


### PR DESCRIPTION
## 📝 PR 설명
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
OAuth2 로그인 성공 시 Access Token을 URL의 Query Parameter로 전달하던 기존 방식을 보안 강화를 위해 HttpOnly Cookie 방식으로 변경했습니다. 이를 통해 브라우저 히스토리나 서버 로그에 토큰이 평문으로 노출되는 리스크를 해소했습니다.

## 🛠 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- CookieUtil: addAccessCookie 메서드를 추가하여 Access Token 전용 보안 쿠키를 생성하는 로직을 구현했습니다.
- OAuth2LoginSuccessHandler: 로그인 성공 리다이렉트 시 쿼리 파라미터에서 accessToken을 제거하고, 대신 쿠키를 통해 토큰을 전달하도록 수정했습니다.
- JwtFilter: resolveToken 메서드를 확장하여 Authorization Header뿐만 아니라 Cookie에서도 토큰을 추출할 수 있도록 지원합니다.

## 🧪 테스트 체크리스트
<!-- 테스트 방법 및 결과를 설명해주세요 -->
- [ ] OAuth2 로그인 성공 후 리다이렉트된 URL에 accessToken 파라미터가 노출되지 않는지 확인.
- [ ] 브라우저 개발자 도구(Application -> Cookies)에서 access_token 쿠키가 HttpOnly 속성으로 정상 생성되는지 확인.
- [ ] 쿠키에 담긴 토큰을 통해 /api/user/me 등 인증이 필요한 API 호출 시 정상적으로 사용자 정보가 조회되는지 확인.
- [ ] 기존 Bearer Header 방식의 인증 요청도 정상적으로 처리되는지(호환성) 확인.

## 📸 스크린샷 또는 비디오
<!-- UI 변경사항이 있는 경우 스크린샷이나 GIF를 첨부해주세요 -->

## ➕ 추가 사항
<!-- PR관련 추가적으로 공지할 내용이나 코드 리뷰 요구사항을 적어주세요 ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 보안 강화를 위해 Access Token 쿠키의 유효 기간을 리프레시 토큰보다 짧게 설정합니다.
- 현재 로컬 테스트를 위해 cookie.setSecure(false)로 설정되어 있으나, 운영 환경 배포 시에는 반드시 true로 변경이 필요합니다.

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했습니다
- [x] 불필요한 코드를 제거했습니다
- [x] 주석 처리를 필요한 만큼 하였습니다.
- [x] PR 제목 또는 설명에 Jira 이슈 키를 포함했습니다

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)

Jira Issue: CST-74
Github Issue: #6 