### PR TITLE
[CST-74] REFACTOR: CookieUtil 추출 로직 분리 및 JwtFilter 변수명 통일

### DIFF
--- a/src/main/java/com/graduationCapstone/Probe/global/security/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/security/jwt/filter/JwtFilter.java
@@ -3,8 +3,10 @@ package com.graduationCapstone.Probe.global.security.jwt.filter;
 import com.graduationCapstone.Probe.global.security.jwt.util.JwtUtil;
 import com.graduationCapstone.Probe.domain.user.entity.User;
 import com.graduationCapstone.Probe.domain.user.repository.UserRepository;
+import com.graduationCapstone.Probe.global.security.util.CookieUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
@@ -23,7 +25,7 @@ import java.util.Collections;
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
-    private final JwtUtil jwtTokenProvider;
+    private final JwtUtil jwtUtil;
     private final UserRepository userRepository;
     private final CookieUtil cookieUtil;
 
@@ -42,9 +44,9 @@ public class JwtFilter extends OncePerRequestFilter {
 
         String jwt = resolveToken(request);
 
-        if (jwt != null && jwtTokenProvider.validateToken(jwt)) {
+        if (jwt != null && jwtUtil.validateToken(jwt)) {
 
-            Long userId = jwtTokenProvider.getUserId(jwt);
+            Long userId = jwtUtil.getUserId(jwt);
             User user = userRepository.findByIdAndDeletedFalse(userId).orElse(null);
 
             if (user != null) {
@@ -72,14 +74,6 @@ public class JwtFilter extends OncePerRequestFilter {
         }
 
         // 헤더에 없다면 쿠키에서 추출 시도
-        Cookie[] cookies = request.getCookies();
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if (ACCESS_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
-                    return cookie.getValue();
-                }
-            }
-        }
-        return null;
+        return cookieUtil.getCookieValue(request, ACCESS_TOKEN_COOKIE_NAME);
     }
 }

--- a/src/main/java/com/graduationCapstone/Probe/global/security/util/CookieUtil.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/security/util/CookieUtil.java
@@ -6,6 +6,10 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Stream;
+
 @Component
 public class CookieUtil {
 
@@ -67,5 +71,16 @@ public class CookieUtil {
         cookie.setPath("/");
         cookie.setMaxAge((int) (accessTokenExpirationMinutes * 60));
         response.addCookie(cookie);
+    }
+
+    // 특정 이름의 쿠키 값을 추출
+    public String getCookieValue(HttpServletRequest request, String name) {
+        return Optional.ofNullable(request.getCookies())
+                .map(Arrays::stream)
+                .orElseGet(Stream::empty)
+                .filter(cookie -> name.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
     }
 }


### PR DESCRIPTION
## 📝 PR 설명
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
단일 책임 원칙, 재사용성, 가독성을 높이기 위해 로직을 Utility 클래스로 분리 및 변수명 수정했습니다. 

## 🛠 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- CookieUtil로 쿠키 추출 로직 이관 (재사용성 향상)
- JwtFilter 내 jwtprovider -> jwtUtil 명칭 통일 (가독성 향상)
- OAuth2LoginSuccessHandler 보안 취약점 해결

## 🧪 테스트 체크리스트
<!-- 테스트 방법 및 결과를 설명해주세요 -->
- [ ] OAuth2 로그인 성공 후 리다이렉트된 URL에 accessToken 파라미터가 노출되지 않는지 확인.
- [ ] 브라우저 개발자 도구(Application -> Cookies)에서 access_token 쿠키가 HttpOnly 속성으로 정상 생성되는지 확인.
- [ ] 쿠키에 담긴 토큰을 통해 /api/user/me 등 인증이 필요한 API 호출 시 정상적으로 사용자 정보가 조회되는지 확인.
- [ ] 기존 Bearer Header 방식의 인증 요청도 정상적으로 처리되는지(호환성) 확인.

## 📸 스크린샷 또는 비디오
<!-- UI 변경사항이 있는 경우 스크린샷이나 GIF를 첨부해주세요 -->

## ➕ 추가 사항
<!-- PR관련 추가적으로 공지할 내용이나 코드 리뷰 요구사항을 적어주세요 ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다
- [ ] 불필요한 코드를 제거했습니다
- [ ] 주석 처리를 필요한 만큼 하였습니다.
- [ ] PR 제목 또는 설명에 Jira 이슈 키를 포함했습니다

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)

Jira Issue: CST-74