### PR TITLE
[Cst 97] fix: OWNER/MEMBER 권한 체계 도입, GitHub 프로필 이미지 연동, 내 정보 조회 시 반환값 수정, 로그 추가

### DIFF
--- a/src/main/java/com/graduationCapstone/Probe/domain/github/service/GithubRepoService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/github/service/GithubRepoService.java
@@ -8,6 +8,7 @@ import com.graduationCapstone.Probe.domain.user.entity.User;
 import com.graduationCapstone.Probe.global.exception.ErrorCode;
 import com.graduationCapstone.Probe.global.exception.handler.CustomException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Mono;
@@ -16,6 +17,7 @@ import reactor.core.scheduler.Schedulers;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GithubRepoService {
@@ -24,25 +26,32 @@ public class GithubRepoService {
 
     @Transactional
     public Mono<GithubRepoResponseDto> upsertRepo(User user, GithubRepoSummaryDto dto) {
+        log.info("GitHub 레포지토리 정보 저장/업데이트 시도: user={}, repoName={}", user.getUsername(), dto.repoName());
         return Mono.fromCallable(() -> {
             GithubRepo repo = githubRepoRepository.findByUserIdAndRepoName(user.getId(), dto.repoName())
                     .map(existing -> {
                         existing.updateFromSummary(dto);
                         return existing;
                     })
-                    .orElseGet(() -> GithubRepo.builder()
-                            .repoName(dto.repoName()).owner(dto.owner()).description(dto.description())
-                            .language(dto.language()).forksCount(dto.forksCount())
-                            .stargazersCount(dto.stargazersCount()).openIssuesCount(dto.openIssuesCount())
-                            .user(user).build());
+                    .orElseGet(() -> {
+                        log.debug("새로운 레포지토리 정보 생성: {}", dto.repoName());
+                        return GithubRepo.builder()
+                                .repoName(dto.repoName()).owner(dto.owner()).description(dto.description())
+                                .language(dto.language()).forksCount(dto.forksCount())
+                                .stargazersCount(dto.stargazersCount()).openIssuesCount(dto.openIssuesCount())
+                                .user(user).build();
+                    });
 
             GithubRepo saved = githubRepoRepository.save(repo);
             return mapToResponse(saved);
-        }).subscribeOn(Schedulers.boundedElastic());
+        }).subscribeOn(Schedulers.boundedElastic())
+                .doOnSuccess(res -> log.info("레포지토리 정보 저장 완료: id={}", res.id()))
+                .doOnError(e -> log.error("레포지토리 정보 저장 실패: {}", e.getMessage()));
     }
 
     @Transactional(readOnly = true)
     public Mono<List<GithubRepoResponseDto>> getUserRepos(Long userId) {
+        log.info("사용자 레포지토리 목록 조회 시도: userId={}", userId);
         return Mono.fromCallable(() -> githubRepoRepository.findByUserId(userId).stream()
                         .map(this::mapToResponse)
                         .collect(Collectors.toList()))
@@ -51,12 +60,21 @@ public class GithubRepoService {
 
     @Transactional
     public Mono<Void> deleteRepo(Long repoId, Long userId) {
+        log.info("레포지토리 삭제 시도: repoId={}, userId={}", repoId, userId);
         return Mono.fromRunnable(() -> {
             GithubRepo repo = githubRepoRepository.findById(repoId)
-                    .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
-            if (!repo.getUser().getId().equals(userId)) throw new CustomException(ErrorCode.ACCESS_DENIED);
+                    .orElseThrow(() -> {
+                        log.error("삭제 실패: 리소스를 찾을 수 없음 - repoId={}", repoId);
+                        return new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+                    });
+            if (!repo.getUser().getId().equals(userId)) {
+                log.warn("삭제 거부: 권한 없음 - userId={}, targetRepoOwnerId={}", userId, repo.getUser().getId());
+                throw new CustomException(ErrorCode.ACCESS_DENIED);
+            }
             githubRepoRepository.delete(repo);
-        }).subscribeOn(Schedulers.boundedElastic()).then();
+        }).subscribeOn(Schedulers.boundedElastic())
+                .doOnSuccess(v -> log.info("레포지토리 삭제 성공: repoId={}", repoId))
+                .then();
     }
 
     private GithubRepoResponseDto mapToResponse(GithubRepo repo) {

--- a/src/main/java/com/graduationCapstone/Probe/domain/github/service/GithubService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/github/service/GithubService.java
@@ -5,6 +5,7 @@ import com.graduationCapstone.Probe.domain.github.dto.GithubRepoDto;
 import com.graduationCapstone.Probe.domain.github.dto.GithubRepoSummaryDto;
 import com.graduationCapstone.Probe.global.exception.ErrorCode;
 import com.graduationCapstone.Probe.global.exception.handler.CustomException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
@@ -17,6 +18,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @Service
 public class GithubService {
 
@@ -38,12 +40,15 @@ public class GithubService {
      * @return 레포지토리 요약 정보 리스트를 포함한 Mono
      */
     public Mono<List<GithubRepoSummaryDto>> getRepoList(String token) {
+        log.info("GitHub API 레포지토리 목록 요청 시작");
         return webClient.get()
                 .uri("/user/repos?sort=updated&per_page=30")
                 .headers(h -> h.setBearerAuth(token))
                 .retrieve()
                 .onStatus(status -> status.equals(HttpStatus.UNAUTHORIZED),
-                        response -> Mono.error(new CustomException(ErrorCode.UNAUTHORIZED_ACCESS)))
+                        response -> {
+                            log.error("GitHub API 인증 실패: 401 Unauthorized");
+                            return Mono.error(new CustomException(ErrorCode.UNAUTHORIZED_ACCESS));})
                 .bodyToFlux(new ParameterizedTypeReference<Map<String, Object>>() {})
                 .map(repo -> new GithubRepoSummaryDto(
                         (String) repo.get("name"),
@@ -55,8 +60,14 @@ public class GithubService {
                         repo.get("open_issues_count") != null ? (int) repo.get("open_issues_count") : 0
                 ))
                 .collectList()
-                .onErrorMap(e -> !(e instanceof CustomException),
-                        e -> new CustomException(ErrorCode.INTERNAL_SERVER_ERROR));
+                .doOnSuccess(list -> log.info("GitHub 레포지토리 목록 조회 완료: count={}", list.size()))
+                .onErrorMap(e -> {
+                    if (!(e instanceof CustomException)) {
+                        log.error("GitHub API 목록 조회 중 오류 발생: {}", e.getMessage());
+                        return new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+                    }
+                    return e;
+                });
     }
 
     /**
@@ -69,6 +80,7 @@ public class GithubService {
      * @return 레포지토리 이름과 파일 리스트를 포함한 GithubRepoDto를 담은 Mono
      */
     public Mono<GithubRepoDto> getRepoFullCode(String owner, String repo, String token) {
+        log.info("레포지토리 전체 코드 추출 시작: owner={}, repo={}", owner, repo);
         return webClient.get()
                 .uri("/repos/{owner}/{repo}", owner, repo)
                 .headers(h -> h.setBearerAuth(token))
@@ -77,6 +89,7 @@ public class GithubService {
                 })
                 .flatMap(repoInfo -> {
                     String defaultBranch = (String) repoInfo.get("default_branch");
+                    log.debug("기본 브랜치 확인: {}", defaultBranch);
 
                     return webClient.get()
                             .uri("/repos/{owner}/{repo}/git/trees/{branch}?recursive=1", owner, repo, defaultBranch)
@@ -91,6 +104,7 @@ public class GithubService {
 
                                 @SuppressWarnings("unchecked")
                                 List<Map<String, Object>> tree = (List<Map<String, Object>>) treeObj;
+                                log.info("Git Tree API 호출 성공: 전체 노드 수={}", tree.size());
 
                                 return Flux.fromIterable(tree)
                                         .filter(node -> "blob".equals(node.get("type"))) // blob(파일)만 선택
@@ -101,9 +115,15 @@ public class GithubService {
                                             return fetchFileContent(apiUrl, path, token);
                                         }, 10)
                                         .collectList()
-                                        .map(files -> new GithubRepoDto(repo, files));
+                                        .map(files -> {
+                                            log.info("코드 추출 완료: {} 개 파일 로드됨", files.size());
+                                            return new GithubRepoDto(repo, files);
+                                        });
                             })
-                            .onErrorResume(e -> Mono.empty());
+                            .onErrorResume(e -> {
+                                log.error("Git Tree 처리 중 오류 발생: {}", e.getMessage());
+                                return Mono.empty();
+                            });
                 });
     }
 
@@ -128,8 +148,7 @@ public class GithubService {
                 .bodyToMono(byte[].class)
                 .map(bytes -> new GithubFileDto(fileName, new String(bytes, StandardCharsets.UTF_8)))
                 .onErrorResume(e -> {
-                    // 시스템 로그에만 원인 출력한 뒤 계속 나머지 파일들 불러오도록 함
-                    System.err.println("[GitHub API Error] 파일 로드 실패: " + fileName + " | 사유: " + e.getMessage());
+                    log.error("[GitHub API Error] 파일 로드 실패: {} | 사유: {}", fileName, e.getMessage());
                     return Mono.just(new GithubFileDto(fileName, ErrorCode.FILE_NOT_FOUND.getMessage()));
                 });
     }

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/controller/ProjectController.java
@@ -101,6 +101,7 @@ public class ProjectController {
             @AuthenticationPrincipal User user,
             @PathVariable Long projectId,
             @Valid @RequestBody ProjectRepoUpdateRequestDto request) {
+        if (user == null) throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
         return projectService.updateProjectRepos(projectId, user.getId(), request.repoIds())
                 .thenReturn(ResponseEntity.ok().build());
     }

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/controller/ProjectController.java
@@ -41,7 +41,7 @@ public class ProjectController {
     public Mono<ResponseEntity<ProjectResponseDto>> createProject(
             @AuthenticationPrincipal User user,
             @Valid @RequestBody ProjectCreateRequestDto request) {
-        if (user == null) return Mono.error(new CustomException(ErrorCode.UNAUTHORIZED_ACCESS));
+        if (user == null) throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
         return projectService.createProject(user, request).map(ResponseEntity::ok);
     }
 
@@ -53,7 +53,7 @@ public class ProjectController {
     })
     @GetMapping
     public Mono<ResponseEntity<List<ProjectResponseDto>>> getMyProjects(@AuthenticationPrincipal User user) {
-        if (user == null) return Mono.error(new CustomException(ErrorCode.UNAUTHORIZED_ACCESS));
+        if (user == null) throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
         return projectService.getMyProjects(user)
                 .collectList()
                 .map(ResponseEntity::ok);
@@ -70,6 +70,7 @@ public class ProjectController {
             @AuthenticationPrincipal User user,
             @PathVariable Long projectId,
             @Valid @RequestBody ProjectNameUpdateRequestDto request) {
+        if (user == null) throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
         return projectService.updateProjectName(projectId, user.getId(), request.projectName())
                 .thenReturn(ResponseEntity.ok().build());
     }
@@ -84,6 +85,7 @@ public class ProjectController {
     public Mono<ResponseEntity<Void>> deleteProject(
             @AuthenticationPrincipal User user,
             @PathVariable Long projectId) {
+        if (user == null) throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
         return projectService.deleteProject(projectId, user.getId())
                 .thenReturn(ResponseEntity.noContent().build());
     }
@@ -198,6 +200,7 @@ public class ProjectController {
             @RequestParam String keyword,
             @AuthenticationPrincipal User user
     ) {
+        if (user == null) throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
         return projectService.searchUsers(keyword, user)
                 .collectList()
                 .map(ResponseEntity::ok);

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/controller/ProjectController.java
@@ -67,25 +67,28 @@ public class ProjectController {
     })
     @PatchMapping("/{projectId}/name")
     public Mono<ResponseEntity<Void>> updateProjectName(
+            @AuthenticationPrincipal User user,
             @PathVariable Long projectId,
             @Valid @RequestBody ProjectNameUpdateRequestDto request) {
-        return projectService.updateProjectName(projectId, request.projectName())
+        return projectService.updateProjectName(projectId, user.getId(), request.projectName())
                 .thenReturn(ResponseEntity.ok().build());
     }
 
-    @Operation(summary = "프로젝트 삭제",
+    @Operation(summary = "프로젝트 삭제(OWNER 전용)",
                description = "프로젝트를 삭제하고 연관된 멤버 및 레포지토리 연결 정보를 모두 제거합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "삭제 성공 (No Content)"),
             @ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음")
     })
     @DeleteMapping("/{projectId}")
-    public Mono<ResponseEntity<Void>> deleteProject(@PathVariable Long projectId) {
-        return projectService.deleteProject(projectId)
+    public Mono<ResponseEntity<Void>> deleteProject(
+            @AuthenticationPrincipal User user,
+            @PathVariable Long projectId) {
+        return projectService.deleteProject(projectId, user.getId())
                 .thenReturn(ResponseEntity.noContent().build());
     }
 
-    @Operation(summary = "프로젝트 레포지토리 목록 변경",
+    @Operation(summary = "프로젝트 레포지토리 목록 변경(OWNER 전용)",
                description = "기존 연결을 초기화하고 새로운 레포지토리 목록으로 교체합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "변경 성공"),
@@ -93,9 +96,10 @@ public class ProjectController {
     })
     @PutMapping("/{projectId}/repos")
     public Mono<ResponseEntity<Void>> updateProjectRepos(
+            @AuthenticationPrincipal User user,
             @PathVariable Long projectId,
             @Valid @RequestBody ProjectRepoUpdateRequestDto request) {
-        return projectService.updateProjectRepos(projectId, request.repoIds())
+        return projectService.updateProjectRepos(projectId, user.getId(), request.repoIds())
                 .thenReturn(ResponseEntity.ok().build());
     }
 

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/dto/ProjectMemberResponseDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/dto/ProjectMemberResponseDto.java
@@ -1,6 +1,7 @@
 package com.graduationCapstone.Probe.domain.project.dto;
 
 import com.graduationCapstone.Probe.domain.project.entity.ProjectMember;
+import com.graduationCapstone.Probe.domain.project.entity.ProjectRole;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "프로젝트 멤버 상세 정보 응답 DTO")
@@ -12,13 +13,17 @@ public record ProjectMemberResponseDto(
         String username,
 
         @Schema(description = "사용자 이메일", example = "probe@gmail.com", requiredMode = Schema.RequiredMode.REQUIRED)
-        String email
+        String email,
+
+        @Schema(description = "프로젝트에서의 권한", example = "OWNER", requiredMode = Schema.RequiredMode.REQUIRED)
+        ProjectRole role
 ) {
     public static ProjectMemberResponseDto from(ProjectMember member) {
         return new ProjectMemberResponseDto(
                 member.getUser().getId(),
                 member.getUser().getUsername(),
-                member.getUser().getEmail()
+                member.getUser().getEmail(),
+                member.getRole()
         );
     }
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/dto/ProjectMemberResponseDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/dto/ProjectMemberResponseDto.java
@@ -15,6 +15,9 @@ public record ProjectMemberResponseDto(
         @Schema(description = "사용자 이메일", example = "probe@gmail.com", requiredMode = Schema.RequiredMode.REQUIRED)
         String email,
 
+        @Schema(description = "GitHub 프로필 이미지 URL", example = "https://...", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String profileImageUrl,
+
         @Schema(description = "프로젝트에서의 권한", example = "OWNER", requiredMode = Schema.RequiredMode.REQUIRED)
         ProjectRole role
 ) {
@@ -23,6 +26,7 @@ public record ProjectMemberResponseDto(
                 member.getUser().getId(),
                 member.getUser().getUsername(),
                 member.getUser().getEmail(),
+                member.getUser().getProfileImageUrl(),
                 member.getRole()
         );
     }

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/dto/UserSearchResponseDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/dto/UserSearchResponseDto.java
@@ -12,13 +12,17 @@ public record UserSearchResponseDto(
         String username,
 
         @Schema(description = "사용자 이메일", example = "probe@gmail.com", requiredMode = Schema.RequiredMode.REQUIRED)
-        String email
+        String email,
+
+        @Schema(description = "GitHub 프로필 이미지 URL", example = "https://...", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String profileImageUrl
 ) {
     public static UserSearchResponseDto from(User user) {
         return new UserSearchResponseDto(
                 user.getId(),
                 user.getUsername(),
-                user.getEmail()
+                user.getEmail(),
+                user.getProfileImageUrl()
         );
     }
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/entity/ProjectMember.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/entity/ProjectMember.java
@@ -26,6 +26,10 @@ public class ProjectMember {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ProjectRole role;
+
     public void setProject(Project project) {
         if (this.project != null) {
             this.project.getMembers().remove(this);

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/entity/ProjectMember.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/entity/ProjectMember.java
@@ -9,7 +9,6 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@EqualsAndHashCode(of = "id")
 @Table(name = "project_member", uniqueConstraints = {
         @UniqueConstraint(columnNames = {"project_id", "user_id"})
 })
@@ -29,6 +28,18 @@ public class ProjectMember {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ProjectRole role;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ProjectMember that)) return false;
+        return id != null && id.equals(that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return 31;
+    }
 
     public void setProject(Project project) {
         if (this.project != null) {

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/entity/ProjectRepo.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/entity/ProjectRepo.java
@@ -9,7 +9,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@EqualsAndHashCode(of = "id")
+@EqualsAndHashCode(of = "githubRepo")
 @Table(name = "project_repo", uniqueConstraints = {
         @UniqueConstraint(columnNames = {"project_id", "github_repo_id"})
 })

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/entity/ProjectRepo.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/entity/ProjectRepo.java
@@ -9,7 +9,6 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@EqualsAndHashCode(of = "githubRepo")
 @Table(name = "project_repo", uniqueConstraints = {
         @UniqueConstraint(columnNames = {"project_id", "github_repo_id"})
 })
@@ -25,6 +24,20 @@ public class ProjectRepo {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "github_repo_id", nullable = false)
     private GithubRepo githubRepo;
+
+    // Lombok의 @EqualsAndHashCode 대신 직접 구현하여 안정성 확보
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ProjectRepo that)) return false;
+        // ID가 있을 때만 ID로 비교, ID가 없는 신규 객체는 무조건 다른 객체로 취급
+        return id != null && id.equals(that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return 31; // 모든 객체가 동일한 해시값을 갖게 하여 HashSet이 equals()를 강제 호출하게 함
+    }
 
     public void setProject(Project project) {
         if (this.project != null) {

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/entity/ProjectRole.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/entity/ProjectRole.java
@@ -1,0 +1,5 @@
+package com.graduationCapstone.Probe.domain.project.entity;
+
+public enum ProjectRole {
+    OWNER, MEMBER
+}

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/repository/ProjectMemberRepository.java
@@ -1,6 +1,7 @@
 package com.graduationCapstone.Probe.domain.project.repository;
 
 import com.graduationCapstone.Probe.domain.project.entity.ProjectMember;
+import com.graduationCapstone.Probe.domain.project.entity.ProjectRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,6 +15,8 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
             "JOIN FETCH pm.user " +
             "WHERE pm.project.id = :projectId AND pm.user.id = :userId")
     Optional<ProjectMember> findByProjectIdAndUserId(@Param("projectId") Long projectId, @Param("userId") Long userId);
+
+    boolean existsByProjectIdAndUserIdAndRole(Long projectId, Long userId, ProjectRole role);
 
     @Query("SELECT pm FROM ProjectMember pm " +
             "JOIN FETCH pm.user " +

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/repository/ProjectMemberRepository.java
@@ -16,7 +16,11 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
             "WHERE pm.project.id = :projectId AND pm.user.id = :userId")
     Optional<ProjectMember> findByProjectIdAndUserId(@Param("projectId") Long projectId, @Param("userId") Long userId);
 
-    boolean existsByProjectIdAndUserIdAndRole(Long projectId, Long userId, ProjectRole role);
+    @Query("SELECT COUNT(pm) > 0 FROM ProjectMember pm " +
+            "WHERE pm.project.id = :projectId " +
+            "AND pm.user.id = :userId " +
+            "AND pm.role = :role")
+    boolean existsByProjectIdAndUserIdAndRole(@Param("projectId") Long projectId, @Param("userId") Long userId, @Param("role") ProjectRole role);
 
     @Query("SELECT pm FROM ProjectMember pm " +
             "JOIN FETCH pm.user " +

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/service/ProjectService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/service/ProjectService.java
@@ -63,6 +63,7 @@ public class ProjectService {
      */
     @Transactional
     public Mono<ProjectResponseDto> createProject(User user, ProjectCreateRequestDto request) {
+        log.info("프로젝트 생성 시작: creator={}, projectName={}", user.getUsername(), request.projectName());
         return Mono.fromCallable(() -> {
             User persistentUser = userRepository.findById(user.getId())
                     .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -92,8 +93,10 @@ public class ProjectService {
                 }
             }
             Project savedProject = projectRepository.save(project);
+            log.info("프로젝트 생성 성공: id={}", savedProject.getId());
             return ProjectResponseDto.from(savedProject);
-        }).subscribeOn(Schedulers.boundedElastic());
+        }).subscribeOn(Schedulers.boundedElastic())
+                .doOnError(e -> log.error("프로젝트 생성 실패: {}", e.getMessage()));
     }
 
     /**
@@ -108,8 +111,10 @@ public class ProjectService {
      * @return 프로젝트 목록
      */
     public Flux<ProjectResponseDto> getMyProjects(User user) {
+        log.info("내 프로젝트 목록 조회: userId={}", user.getId());
         return Mono.fromCallable(() -> {
                     List<Project> projects = projectRepository.findAllByUserId(user.getId());
+                    log.debug("조회된 프로젝트 수: {}", projects.size());
                     if (projects.isEmpty()) return List.<ProjectResponseDto>of();
 
                     List<Long> projectIds = projects.stream().map(Project::getId).toList();
@@ -126,7 +131,8 @@ public class ProjectService {
 
                         return ProjectResponseDto.of(project, memberCount, repoCount);
                     }).toList();
-                }).subscribeOn(Schedulers.boundedElastic()).flatMapMany(Flux::fromIterable);
+                }).subscribeOn(Schedulers.boundedElastic()).flatMapMany(Flux::fromIterable)
+                .doOnError(e -> log.error("프로젝트 목록 조회 중 에러: {}", e.getMessage()));
     }
 
     /**
@@ -139,12 +145,14 @@ public class ProjectService {
      */
     @Transactional
     public Mono<Void> updateProjectName(Long projectId, Long userId, String newProjectName) {
+        log.info("프로젝트명 수정 시도: projectId={}, userId={}, newName={}", projectId, userId, newProjectName);
         return Mono.fromRunnable(() -> {
             validateOwner(projectId, userId);
 
             Project project = projectRepository.findById(projectId)
                     .orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND));
             project.updateProjectName(newProjectName);
+            log.info("프로젝트명 수정 완료: projectId={}", projectId);
         }).subscribeOn(Schedulers.boundedElastic()).then();
     }
 
@@ -160,6 +168,7 @@ public class ProjectService {
      */
     @Transactional
     public Mono<Void> deleteProject(Long projectId, Long userId) {
+        log.warn("프로젝트 삭제 시도: projectId={}, userId={}", projectId, userId);
         return Mono.fromRunnable(() -> {
             validateOwner(projectId, userId);
 
@@ -167,6 +176,7 @@ public class ProjectService {
                 throw new CustomException(ErrorCode.PROJECT_NOT_FOUND);
             }
             projectRepository.deleteById(projectId);
+            log.info("프로젝트 삭제 완료: projectId={}", projectId);
         }).subscribeOn(Schedulers.boundedElastic()).then();
     }
 
@@ -204,6 +214,7 @@ public class ProjectService {
      */
     @Transactional
     public Mono<Void> inviteMembers(Long projectId, List<String> emails) {
+        log.info("프로젝트 멤버 초대 시작: projectId={}, targetEmails={}", projectId, emails);
         return Mono.fromCallable(() -> projectRepository.findById(projectId)
                         .orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND)))
                 .subscribeOn(Schedulers.boundedElastic())
@@ -211,8 +222,14 @@ public class ProjectService {
                     String projectName = project.getProjectName();
 
                     return Flux.fromIterable(emails)
-                            .flatMap(email -> sendInviteToSingleUser(projectId, email, projectName)
-                                    .onErrorResume(e -> Mono.empty()))
+                            .flatMap(email -> {
+                                log.debug("초대 메일 발송 큐 등록: {}", email);
+                                return sendInviteToSingleUser(projectId, email, projectName)
+                                        .onErrorResume(e -> {
+                                            log.error("초대 실패: email={}, error={}", email, e.getMessage());
+                                            return Mono.empty();
+                                        });
+                            })
                             .then();
                 });
     }
@@ -261,12 +278,17 @@ public class ProjectService {
      */
     @Transactional
     public Mono<Void> acceptInvitationByToken(String token) {
+        log.info("초대 수락 시도: tokenKey=invite:{}", token);
         String redisKey = "invite:" + token;
         return redisTemplate.opsForValue().get(redisKey)
-                .switchIfEmpty(Mono.defer(() -> Mono.error(new CustomException(ErrorCode.INVITATION_NOT_FOUND))))
+                .switchIfEmpty(Mono.defer(() -> {
+                    log.warn("초대 수락 실패: 존재하지 않거나 만료된 토큰");
+                    return Mono.error(new CustomException(ErrorCode.INVITATION_NOT_FOUND));
+                }))
                 .flatMap(jsonValue -> {
                     try {
                         InviteTokenInfo info = objectMapper.readValue(jsonValue, InviteTokenInfo.class);
+                        log.debug("토큰 파싱 성공: projectId={}, email={}", info.projectId(), info.inviteEmail());
                         return saveMemberToDb(info.projectId(), info.inviteEmail());
                     } catch (JsonProcessingException e) {
                         log.error("초대 토큰 파싱 중 오류 발생: {}", e.getMessage(), e);
@@ -274,6 +296,7 @@ public class ProjectService {
                     }
                 })
                 .then(redisTemplate.opsForValue().delete(redisKey))
+                .doOnSuccess(v -> log.info("초대 수락 및 멤버 등록 완료"))
                 .then();
     }
 
@@ -339,6 +362,7 @@ public class ProjectService {
      */
     @Transactional
     public Mono<Void> removeMember(Long projectId, Long userId) {
+        log.info("멤버 프로젝트 탈퇴 시도: projectId={}, userId={}", projectId, userId);
         return Mono.fromRunnable(() -> {
             ProjectMember member = projectMemberRepository.findByProjectIdAndUserId(projectId, userId)
                     .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -347,7 +371,9 @@ public class ProjectService {
                 throw new CustomException(ErrorCode.OWNER_CANNOT_LEAVE);
             }
             projectMemberRepository.delete(member);
-        }).subscribeOn(Schedulers.boundedElastic()).then();
+        }).subscribeOn(Schedulers.boundedElastic())
+                .doOnSuccess(v -> log.info("멤버 탈퇴 완료: userId={}", userId))
+                .then();
     }
 
     /**
@@ -409,6 +435,7 @@ public class ProjectService {
                 projectId, userId, ProjectRole.OWNER);
 
         if (!isOwner) {
+            log.warn("권한 검증 실패: 소유자 아님 - projectId={}, userId={}", projectId, userId);
             throw new CustomException(ErrorCode.NOT_PROJECT_OWNER);
         }
     }

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/service/ProjectService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/service/ProjectService.java
@@ -9,6 +9,7 @@ import com.graduationCapstone.Probe.domain.project.dto.*;
 import com.graduationCapstone.Probe.domain.project.entity.Project;
 import com.graduationCapstone.Probe.domain.project.entity.ProjectMember;
 import com.graduationCapstone.Probe.domain.project.entity.ProjectRepo;
+import com.graduationCapstone.Probe.domain.project.entity.ProjectRole;
 import com.graduationCapstone.Probe.domain.project.repository.ProjectMemberRepository;
 import com.graduationCapstone.Probe.domain.project.repository.ProjectRepoRepository;
 import com.graduationCapstone.Probe.domain.project.repository.ProjectRepository;
@@ -72,6 +73,7 @@ public class ProjectService {
 
             ProjectMember member = ProjectMember.builder()
                     .user(persistentUser)
+                    .role(ProjectRole.OWNER)
                     .build();
             project.addMember(member);
 
@@ -136,8 +138,10 @@ public class ProjectService {
      * @throws CustomException PROJECT_NOT_FOUND (프로젝트가 없을 경우)
      */
     @Transactional
-    public Mono<Void> updateProjectName(Long projectId, String newProjectName) {
+    public Mono<Void> updateProjectName(Long projectId, Long userId, String newProjectName) {
         return Mono.fromRunnable(() -> {
+            validateOwner(projectId, userId);
+
             Project project = projectRepository.findById(projectId)
                     .orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND));
             project.updateProjectName(newProjectName);
@@ -155,8 +159,10 @@ public class ProjectService {
      * @throws CustomException PROJECT_NOT_FOUND (프로젝트가 없을 경우)
      */
     @Transactional
-    public Mono<Void> deleteProject(Long projectId) {
+    public Mono<Void> deleteProject(Long projectId, Long userId) {
         return Mono.fromRunnable(() -> {
+            validateOwner(projectId, userId);
+
             if (!projectRepository.existsById(projectId)) {
                 throw new CustomException(ErrorCode.PROJECT_NOT_FOUND);
             }
@@ -293,6 +299,7 @@ public class ProjectService {
             if (!isAlreadyMember) {
                 ProjectMember newMember = ProjectMember.builder()
                         .user(user)
+                        .role(ProjectRole.MEMBER)
                         .build();
                 project.addMember(newMember);
                 projectRepository.save(project);
@@ -335,6 +342,10 @@ public class ProjectService {
         return Mono.fromRunnable(() -> {
             ProjectMember member = projectMemberRepository.findByProjectIdAndUserId(projectId, userId)
                     .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+            if (member.getRole() == ProjectRole.OWNER){
+                throw new CustomException(ErrorCode.OWNER_CANNOT_LEAVE);
+            }
             projectMemberRepository.delete(member);
         }).subscribeOn(Schedulers.boundedElastic()).then();
     }
@@ -349,8 +360,9 @@ public class ProjectService {
      * @throws CustomException PROJECT_NOT_FOUND
      */
     @Transactional
-    public Mono<Void> updateProjectRepos(Long projectId, List<Long> newRepoIds) {
+    public Mono<Void> updateProjectRepos(Long projectId, Long userId, List<Long> newRepoIds) {
         return Mono.fromRunnable(() -> {
+            validateOwner(projectId, userId);
             Project project = projectRepository.findByIdWithRepos(projectId)
                     .orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND));
 
@@ -390,5 +402,14 @@ public class ProjectService {
                     .map(GithubRepoResponseDto::from)
                     .collect(Collectors.toList());
         }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    private void validateOwner(Long projectId, Long userId) {
+        boolean isOwner = projectMemberRepository.existsByProjectIdAndUserIdAndRole(
+                projectId, userId, ProjectRole.OWNER);
+
+        if (!isOwner) {
+            throw new CustomException(ErrorCode.NOT_PROJECT_OWNER);
+        }
     }
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/service/ProjectService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/service/ProjectService.java
@@ -147,10 +147,9 @@ public class ProjectService {
     public Mono<Void> updateProjectName(Long projectId, Long userId, String newProjectName) {
         log.info("프로젝트명 수정 시도: projectId={}, userId={}, newName={}", projectId, userId, newProjectName);
         return Mono.fromRunnable(() -> {
-            validateOwner(projectId, userId);
-
             Project project = projectRepository.findById(projectId)
                     .orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND));
+            validateOwner(projectId, userId);
             project.updateProjectName(newProjectName);
             log.info("프로젝트명 수정 완료: projectId={}", projectId);
         }).subscribeOn(Schedulers.boundedElastic()).then();
@@ -170,11 +169,9 @@ public class ProjectService {
     public Mono<Void> deleteProject(Long projectId, Long userId) {
         log.warn("프로젝트 삭제 시도: projectId={}, userId={}", projectId, userId);
         return Mono.fromRunnable(() -> {
-            validateOwner(projectId, userId);
-
             if (!projectRepository.existsById(projectId)) {
-                throw new CustomException(ErrorCode.PROJECT_NOT_FOUND);
-            }
+                throw new CustomException(ErrorCode.PROJECT_NOT_FOUND);}
+            validateOwner(projectId, userId);
             projectRepository.deleteById(projectId);
             log.info("프로젝트 삭제 완료: projectId={}", projectId);
         }).subscribeOn(Schedulers.boundedElastic()).then();
@@ -189,19 +186,24 @@ public class ProjectService {
      * @return 검색된 사용자 정보를 담은 리스트
      */
     public Flux<UserSearchResponseDto> searchUsers(String keyword, User currentUser) {
+        log.info("사용자 검색 시작: keyword={}, requester={}", keyword, currentUser.getUsername());
         return Mono.fromCallable(() -> {
                     List<User> users = userRepository.findByUsernameContainingOrEmailContaining(keyword, keyword)
                             .stream()
                             .filter(user -> !user.getId().equals(currentUser.getId()))
                             .toList();
 
-                    if (users.isEmpty()) return List.<UserSearchResponseDto>of();
+                    if (users.isEmpty()) {
+                        log.debug("검색 결과 없음: keyword={}", keyword);
+                        return List.<UserSearchResponseDto>of();
+                    }
 
                     return users.stream()
                             .map(UserSearchResponseDto::from)
                             .toList();
                 }).subscribeOn(Schedulers.boundedElastic())
-                .flatMapMany(Flux::fromIterable);
+                .flatMapMany(Flux::fromIterable)
+                .doOnComplete(() -> log.info("사용자 검색 완료: keyword={}", keyword));
     }
 
     /**
@@ -320,12 +322,15 @@ public class ProjectService {
                     .anyMatch(m -> m.getUser().getId().equals(user.getId()));
 
             if (!isAlreadyMember) {
+                log.info("이미 멤버인 사용자: projectId={}, email={}", projectId, email);
+            } else {
                 ProjectMember newMember = ProjectMember.builder()
                         .user(user)
                         .role(ProjectRole.MEMBER)
                         .build();
                 project.addMember(newMember);
                 projectRepository.save(project);
+                log.info("신규 멤버 등록 성공: projectId={}, email={}", projectId, email);
             }
         }).subscribeOn(Schedulers.boundedElastic()).then();
     }
@@ -338,6 +343,7 @@ public class ProjectService {
      * @throws CustomException ErrorCode.PROJECT_NOT_FOUND - 프로젝트가 존재하지 않을 경우
      */
     public Mono<List<ProjectMemberResponseDto>> getProjectMembers(Long projectId) {
+        log.info("멤버 목록 조회: projectId={}", projectId);
         return Mono.fromCallable(() -> {
             Project project = projectRepository.findByIdWithMembers(projectId)
                     .orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND));
@@ -345,7 +351,8 @@ public class ProjectService {
             return project.getMembers().stream()
                     .map(ProjectMemberResponseDto::from)
                     .toList();
-        }).subscribeOn(Schedulers.boundedElastic());
+        }).subscribeOn(Schedulers.boundedElastic())
+                .doOnSuccess(list -> log.info("멤버 목록 조회 완료: projectId={}, count={}", projectId, list.size()));
     }
 
     /**
@@ -387,10 +394,11 @@ public class ProjectService {
      */
     @Transactional
     public Mono<Void> updateProjectRepos(Long projectId, Long userId, List<Long> newRepoIds) {
+        log.info("레포지토리 목록 수정 시작: projectId={}, userId={}, newRepoIds={}", projectId, userId, newRepoIds);
         return Mono.fromRunnable(() -> {
-            validateOwner(projectId, userId);
             Project project = projectRepository.findByIdWithRepos(projectId)
                     .orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND));
+            validateOwner(projectId, userId);
 
             project.getProjectRepos().clear();
 
@@ -398,6 +406,7 @@ public class ProjectService {
                 List<GithubRepo> repos = githubRepoRepository.findAllById(newRepoIds);
 
                 if (repos.size() != newRepoIds.size()) {
+                    log.error("레포 수정 실패: 일부 레포를 찾을 수 없음 - 요청 IDs: {}", newRepoIds);
                     throw new CustomException(ErrorCode.REPOSITORY_NOT_FOUND);
                 }
 
@@ -409,6 +418,7 @@ public class ProjectService {
                 }
             }
             projectRepository.save(project);
+            log.info("레포지토리 목록 수정 완료: projectId={}", projectId);
         }).subscribeOn(Schedulers.boundedElastic()).then();
     }
 
@@ -419,6 +429,7 @@ public class ProjectService {
      * @return 연결된 레포지토리 정보 리스트
      */
     public Mono<List<GithubRepoResponseDto>> getProjectRepoList(Long projectId) {
+        log.info("프로젝트 레포 목록 조회: projectId={}", projectId);
         return Mono.fromCallable(() -> {
             Project project = projectRepository.findByIdWithRepos(projectId)
                     .orElseThrow(() -> new CustomException(ErrorCode.PROJECT_NOT_FOUND));
@@ -427,7 +438,8 @@ public class ProjectService {
                     .map(ProjectRepo::getGithubRepo)
                     .map(GithubRepoResponseDto::from)
                     .collect(Collectors.toList());
-        }).subscribeOn(Schedulers.boundedElastic());
+        }).subscribeOn(Schedulers.boundedElastic())
+                .doOnSuccess(list -> log.info("레포 목록 조회 완료: projectId={}, count={}", projectId, list.size()));
     }
 
     private void validateOwner(Long projectId, Long userId) {

--- a/src/main/java/com/graduationCapstone/Probe/domain/user/controller/UserController.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/user/controller/UserController.java
@@ -1,7 +1,10 @@
 package com.graduationCapstone.Probe.domain.user.controller;
 
+import com.graduationCapstone.Probe.domain.user.dto.UserResponseDto;
 import com.graduationCapstone.Probe.domain.user.entity.User;
 import com.graduationCapstone.Probe.domain.user.service.UserService;
+import com.graduationCapstone.Probe.global.exception.ErrorCode;
+import com.graduationCapstone.Probe.global.exception.handler.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,6 +19,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import reactor.core.publisher.Mono;
 
 @Tag(name = "사용자 관리 (User)", description = "로그인된 사용자의 정보 조회 및 회원탈퇴")
 @RestController
@@ -25,7 +29,7 @@ public class UserController {
 
     private final UserService userService;
 
-    @Operation(summary = "내 정보 조회", description = "유효한 Access Token으로 현재 로그인된 사용자(User)의 상세 정보를 조회합니다.")
+    @Operation(summary = "내 정보 조회", description = "유효한 Access Token으로 현재 로그인된 사용자(User)의 닉네임, 이메일, 프로필 이미지를 조회합니다.")
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
@@ -39,8 +43,14 @@ public class UserController {
             )
     })
     @GetMapping("/me")
-    public ResponseEntity<User> get(@AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(user);
+    public Mono<ResponseEntity<UserResponseDto>> getMyInfo(@AuthenticationPrincipal User user) {
+        if (user == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        UserResponseDto response = UserResponseDto.from(user);
+
+        return Mono.just(ResponseEntity.ok(response));
     }
 
     @Operation(summary = "회원 탈퇴 (논리적 삭제)", description = "로그인된 사용자 계정을 논리적으로 삭제하고 Refresh Token을 무효화합니다.")

--- a/src/main/java/com/graduationCapstone/Probe/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/user/dto/UserResponseDto.java
@@ -1,0 +1,24 @@
+package com.graduationCapstone.Probe.domain.user.dto;
+
+import com.graduationCapstone.Probe.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "내 정보 조회 응답 데이터")
+public record UserResponseDto(
+        @Schema(description = "사용자 닉네임", example = "MAKC")
+        String username,
+
+        @Schema(description = "사용자 이메일", example = "probe@gmail.com")
+        String email,
+
+        @Schema(description = "GitHub 프로필 이미지 URL")
+        String profileImageUrl
+) {
+    public static UserResponseDto from(User user) {
+        return new UserResponseDto(
+                user.getUsername(),
+                user.getEmail(),
+                user.getProfileImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/graduationCapstone/Probe/domain/user/entity/User.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/user/entity/User.java
@@ -34,6 +34,7 @@ public class User {
     @Column(name = "email", nullable = false, unique = true)
     private String email;
 
+    @Comment("회원의 GitHub 프로필 이미지 URL")
     @Column(name = "profile_image_url")
     private String profileImageUrl;
 

--- a/src/main/java/com/graduationCapstone/Probe/domain/user/entity/User.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/user/entity/User.java
@@ -34,6 +34,9 @@ public class User {
     @Column(name = "email", nullable = false, unique = true)
     private String email;
 
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
     @Comment("회원의 회원 탈퇴 여부")
     @Column(name = "deleted", columnDefinition = "boolean default false")
     private boolean deleted;
@@ -68,5 +71,9 @@ public class User {
 
     public void updateGithubAccessToken(String token) {
         this.githubAccessToken = token;
+    }
+
+    public void updateProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
     }
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/user/service/UserService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/user/service/UserService.java
@@ -7,11 +7,13 @@ import com.graduationCapstone.Probe.global.exception.handler.CustomException;
 import com.graduationCapstone.Probe.global.security.login.repository.RefreshTokenRepository;
 import com.graduationCapstone.Probe.global.security.oauth.dto.OAuth2ResponseDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -28,7 +30,7 @@ public class UserService {
      */
     @Transactional
     public User saveOrUpdateUser(OAuth2ResponseDto attributes) { //CustomOAuth2UserService에서 User 객체 바로 사용할 수 있도록 void -> user 로 리턴 타입 수정
-
+        log.info("OAuth2 유저 정보 저장/업데이트: githubId={}, username={}", attributes.githubId(), attributes.username());
         Optional<User> existingUser = userRepository.findByGithubId(attributes.githubId());
 
         User user;
@@ -38,15 +40,18 @@ public class UserService {
 
             // 탈퇴 계정이라면 재활성화
             if (user.isDeleted()) {
+                log.info("탈퇴 계정 재활성화: userId={}", user.getId());
                 user.reactivate();
                 user.updateUsername(attributes.username());
                 user.updateProfileImageUrl(attributes.profileImageUrl());
             } else {
+                log.debug("기존 사용자 정보 업데이트 진행: userId={}", user.getId());
                 // 기존 사용자: 닉네임과 프로필 이미지 모두 최신 상태로 업데이트
                 user.updateUsername(attributes.username());
                 user.updateProfileImageUrl(attributes.profileImageUrl());
             }
         } else {
+            log.info("신규 사용자 등록 진행: githubId={}", attributes.githubId());
             // 신규 사용자
             user = attributes.toEntity();
         }
@@ -63,13 +68,16 @@ public class UserService {
      */
     @Transactional
     public void deleteUser(Long userId){
-
+        log.info("회원 탈퇴 처리 시작: userId={}", userId);
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                .orElseThrow(() -> {
+                    log.error("탈퇴 실패: 사용자를 찾을 수 없음 - userId={}", userId);
+                    return new CustomException(ErrorCode.USER_NOT_FOUND);
+                });
 
         refreshTokenRepository.deleteByUserId(userId);
-
         user.deleted(true);
+        log.info("회원 탈퇴 처리 완료: userId={}", userId);
     }
 
     /**
@@ -82,6 +90,7 @@ public class UserService {
      */
     @Transactional
     public User updateGithubToken(Long userId, String token) {
+        log.debug("GitHub AccessToken 업데이트: userId={}", userId);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("User not found"));
         user.updateGithubAccessToken(token);

--- a/src/main/java/com/graduationCapstone/Probe/domain/user/service/UserService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/user/service/UserService.java
@@ -92,8 +92,12 @@ public class UserService {
     public User updateGithubToken(Long userId, String token) {
         log.debug("GitHub AccessToken 업데이트: userId={}", userId);
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("User not found"));
+                .orElseThrow(() -> {
+                    log.error("GitHub 토큰 업데이트 실패: 존재하지 않는 사용자 - userId={}", userId);
+                    return new CustomException(ErrorCode.USER_NOT_FOUND);
+                });
         user.updateGithubAccessToken(token);
+        log.info("GitHub AccessToken 업데이트 완료: userId={}", userId);
         return userRepository.saveAndFlush(user);
     }
 

--- a/src/main/java/com/graduationCapstone/Probe/domain/user/service/UserService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/user/service/UserService.java
@@ -40,9 +40,11 @@ public class UserService {
             if (user.isDeleted()) {
                 user.reactivate();
                 user.updateUsername(attributes.username());
+                user.updateProfileImageUrl(attributes.profileImageUrl());
             } else {
-                // 기존 사용자: 닉네임만 업데이트
+                // 기존 사용자: 닉네임과 프로필 이미지 모두 최신 상태로 업데이트
                 user.updateUsername(attributes.username());
+                user.updateProfileImageUrl(attributes.profileImageUrl());
             }
         } else {
             // 신규 사용자

--- a/src/main/java/com/graduationCapstone/Probe/global/config/CorsConfig.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/config/CorsConfig.java
@@ -25,9 +25,10 @@ public class CorsConfig {
 
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type"));
 
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "DELETE", "PATCH", "OPTIONS"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST","PUT", "DELETE", "PATCH", "OPTIONS"));
 
         configuration.setAllowCredentials(true);
+
         configuration.setMaxAge(3600L); // 캐시 시간 1시간
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/graduationCapstone/Probe/global/config/CorsConfig.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/config/CorsConfig.java
@@ -23,7 +23,7 @@ public class CorsConfig {
         // 프론트엔드 URL 목록
         configuration.setAllowedOrigins(allowedOrigins);
 
-        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type"));
+        configuration.setAllowedHeaders(List.of("*"));
 
         configuration.setAllowedMethods(Arrays.asList("GET", "POST","PUT", "DELETE", "PATCH", "OPTIONS"));
 

--- a/src/main/java/com/graduationCapstone/Probe/global/exception/ErrorCode.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "INVALID40003", "유효하지 않은 리프레시 토큰입니다."),
     USER_ROLE_EXCEPTION(HttpStatus.BAD_REQUEST, "USER40001", "존재하지 않는 인가 권한입니다."),
     UNSUPPORTED_OAUTH_PROVIDER(HttpStatus.BAD_REQUEST, "AUTH40001", "지원하지 않는 OAuth 제공자입니다."),
+    OWNER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "PROJ40001", "프로젝트 소유자는 나갈 수 없습니다."),
 
     // 401 UNAUTHORIZED (인증 실패)
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH40101", "토큰이 유효하지 않거나 만료되었습니다."),
@@ -22,6 +23,7 @@ public enum ErrorCode {
 
     // 403 FORBIDDEN (인가 실패 / 접근 권한 없음)
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "AUTH40301", "해당 리소스에 접근할 권한이 없습니다."),
+    NOT_PROJECT_OWNER(HttpStatus.FORBIDDEN, "PROJ40301", "프로젝트 소유자만 접근 가능합니다."),
 
     // 404 NOT FOUND (리소스를 찾지 못함)
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER40401", "회원을 찾지 못했습니다."),

--- a/src/main/java/com/graduationCapstone/Probe/global/security/login/service/LoginService.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/security/login/service/LoginService.java
@@ -8,8 +8,10 @@ import com.graduationCapstone.Probe.global.security.login.entity.RefreshToken;
 import com.graduationCapstone.Probe.global.security.login.repository.RefreshTokenRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -20,7 +22,9 @@ public class LoginService {
 
     // 토큰 재발급 로직
     public TokenResponseDto reissue(String refreshToken) {
+        log.info("토큰 재발급 요청 시작");
         if (!jwtUtil.validateToken(refreshToken)) {
+            log.warn("토큰 재발급 실패: 유효하지 않은 리프레시 토큰");
             throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
@@ -38,12 +42,14 @@ public class LoginService {
 
         storedToken.updateToken(newRefreshToken);
 
+        log.info("토큰 재발급 완료: userId={}", userId);
         return new TokenResponseDto(newAccessToken, newRefreshToken);
     }
 
     // 로그아웃 로직
     public void logout(String accessToken) {
         Long userId = jwtUtil.getUserId(accessToken);
+        log.info("로그아웃: userId={}", userId);
         refreshTokenRepository.deleteByUserId(userId);
     }
 }

--- a/src/main/java/com/graduationCapstone/Probe/global/security/login/service/RefreshTokenService.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/security/login/service/RefreshTokenService.java
@@ -5,8 +5,10 @@ import com.graduationCapstone.Probe.global.security.login.entity.RefreshToken;
 import com.graduationCapstone.Probe.global.security.login.repository.RefreshTokenRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -15,15 +17,19 @@ public class RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
 
     public void saveOrUpdate(RefreshTokenSaveDto dto) {
+        log.debug("리프레시 토큰 저장/업데이트 시도: userId={}", dto.userId());
         refreshTokenRepository.findByUserId(dto.userId())
                 .ifPresentOrElse(
                         r -> r.updateToken(dto.refreshToken()),
-                        () -> refreshTokenRepository.save(
-                                RefreshToken.builder()
-                                        .userId(dto.userId())
-                                        .refreshToken(dto.refreshToken())
-                                        .build()
-                        )
+                        () -> {
+                            log.info("신규 리프레시 토큰 저장: userId={}", dto.userId());
+                            refreshTokenRepository.save(
+                                    RefreshToken.builder()
+                                            .userId(dto.userId())
+                                            .refreshToken(dto.refreshToken())
+                                            .build()
+                            );
+                        }
                 );
     }
 }

--- a/src/main/java/com/graduationCapstone/Probe/global/security/oauth/dto/OAuth2ResponseDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/security/oauth/dto/OAuth2ResponseDto.java
@@ -20,7 +20,10 @@ public record OAuth2ResponseDto (
         String username,
 
         @Schema(description = "GitHub 이메일", example = "probe@gmail.com")
-        String email
+        String email,
+
+        @Schema(description = "GitHub 프로필 이미지 URL")
+        String profileImageUrl
 ){
 
     /**
@@ -31,6 +34,7 @@ public record OAuth2ResponseDto (
                 .githubId(this.githubId)
                 .username(this.username)
                 .email(this.email)
+                .profileImageUrl(this.profileImageUrl)
                 .build();
     }
 }

--- a/src/main/java/com/graduationCapstone/Probe/global/security/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/security/oauth/service/CustomOAuth2UserService.java
@@ -7,6 +7,7 @@ import com.graduationCapstone.Probe.global.security.oauth.util.OAuth2Util;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -20,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
@@ -46,12 +48,15 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     @Override
     @Transactional
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        log.info("OAuth2 로그인 시도 - Provider: {}", userRequest.getClientRegistration().getRegistrationId());
 
         OAuth2User oAuth2User = delegate.loadUser(userRequest);
+        log.info("OAuth2 제공자로부터 유저 속성 로드 완료");
 
         // Github가 발급한 실제 AccessToken 추출(Github 서비스 전용 토큰)
         String githubAccessToken = userRequest.getAccessToken().getTokenValue();
         Map<String, Object> attributes = oAuth2User.getAttributes();
+        log.debug("GitHub AccessToken 및 Attributes 추출 완료");
 
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
@@ -62,10 +67,13 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 userNameAttributeName,
                 attributes
         );
+        log.info("OAuth2ResponseDto 변환 성공 - GitHub ID: {}", oAuth2ResponseDto.githubId());
 
         // 리턴받은 user 객체에 GithubAccessToken 업데이트
         User user = userService.saveOrUpdateUser(oAuth2ResponseDto);
+        log.info("사용자 엔티티 저장/업데이트 완료 - User ID: {}", user.getId());
         userService.updateGithubToken(user.getId(), githubAccessToken);
+        log.info("사용자 GitHub AccessToken DB 업데이트 완료");
 
         Map<String, Object> modifiedAttributes = new HashMap<>(attributes);
         modifiedAttributes.put("githubAccessToken", githubAccessToken);

--- a/src/main/java/com/graduationCapstone/Probe/global/security/oauth/util/OAuth2Util.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/security/oauth/util/OAuth2Util.java
@@ -33,6 +33,7 @@ public class OAuth2Util {
         String extractedGithubId = String.valueOf(attributes.get(userNameAttributeName));
         String extractedUsername = (String) attributes.get("login");
         String extractedEmail = (String) attributes.get("email");
+        String extractedAvatarUrl = (String) attributes.get("avatar_url");;
 
         // GithubID 사용하여 서비스 내에서 고유성 보장하는 임시 이메일 생성
         // 이메일 형식: [githubId]_[Timestamp]@no-email.com
@@ -45,7 +46,8 @@ public class OAuth2Util {
                 userNameAttributeName,
                 extractedGithubId,
                 extractedUsername,
-                extractedEmail
+                extractedEmail,
+                extractedAvatarUrl
         );
     }
 }

--- a/src/main/java/com/graduationCapstone/Probe/global/security/oauth/util/OAuth2Util.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/security/oauth/util/OAuth2Util.java
@@ -33,7 +33,7 @@ public class OAuth2Util {
         String extractedGithubId = String.valueOf(attributes.get(userNameAttributeName));
         String extractedUsername = (String) attributes.get("login");
         String extractedEmail = (String) attributes.get("email");
-        String extractedAvatarUrl = (String) attributes.get("avatar_url");;
+        String extractedAvatarUrl = (String) attributes.get("avatar_url");
 
         // GithubID 사용하여 서비스 내에서 고유성 보장하는 임시 이메일 생성
         // 이메일 형식: [githubId]_[Timestamp]@no-email.com

--- a/src/main/java/com/graduationCapstone/Probe/global/security/util/CookieUtil.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/security/util/CookieUtil.java
@@ -4,11 +4,10 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
-import java.util.Optional;
-import java.util.stream.Stream;
 
 @Component
 public class CookieUtil {
@@ -25,62 +24,54 @@ public class CookieUtil {
 
     // Refresh Token 쿠키 생성
     public void addRefreshCookie(HttpServletResponse response, String refreshToken) {
-        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .maxAge(refreshTokenExpirationDays * 24 * 60 * 60)
+                .build();
 
-        // HttpOnly: JavaScript 접근 불가
-        cookie.setHttpOnly(true);
-        // Secure: HTTPS에서만 전송
-        cookie.setSecure(false);
-        // 모든 경로에서 접근 가능
-        cookie.setPath("/");
-        // MaxAge: 초 단위로 설정
-        cookie.setMaxAge((int) (refreshTokenExpirationDays * 24 * 60 * 60));
-
-        response.addCookie(cookie);
+        response.addHeader("Set-Cookie", cookie.toString());
     }
 
     // Refresh Token 쿠키 삭제 (로그아웃 시)
     public void deleteRefreshCookie(HttpServletResponse response) {
-        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, null);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(false);
-        cookie.setPath("/");
-        cookie.setMaxAge(0);
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, null)
+                .path("/")
+                .maxAge(0)
+                .secure(true)
+                .sameSite("None")
+                .httpOnly(true)
+                .build();
 
-        response.addCookie(cookie);
+        response.addHeader("Set-Cookie", cookie.toString());
     }
 
     // Request에서 Refresh Token 가져오기
     public String getRefreshTokenFromCookie(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if (REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
-                    return cookie.getValue();
-                }
-            }
-        }
-        return null;
+        return getCookieValue(request, REFRESH_TOKEN_COOKIE_NAME);
     }
 
-    // Access Token 쿠키 생성
-    public void addAccessCookie(HttpServletResponse response, String accessToken) {
-        Cookie cookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, accessToken);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(false);  // 로컬 개발 환경이므로 false, 배포시 true 설정하여 HTTPS 환경에서만 쿠키가 전송되도록
-        cookie.setPath("/");
-        cookie.setMaxAge((int) (accessTokenExpirationMinutes * 60));
-        response.addCookie(cookie);
-    }
-
-    // 특정 이름의 쿠키 값을 추출
     public String getCookieValue(HttpServletRequest request, String name) {
-        return Optional.ofNullable(request.getCookies())
-                .map(Arrays::stream)
-                .orElseGet(Stream::empty)
+        if (request.getCookies() == null) return null;
+        return Arrays.stream(request.getCookies())
                 .filter(cookie -> name.equals(cookie.getName()))
                 .map(Cookie::getValue)
                 .findFirst()
                 .orElse(null);
+    }
+
+    // Access Token 쿠키 생성
+    public void addAccessCookie(HttpServletResponse response, String accessToken) {
+        ResponseCookie cookie = ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, accessToken)
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .maxAge(accessTokenExpirationMinutes * 60)
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
     }
 }

--- a/src/main/java/com/graduationCapstone/Probe/global/security/util/CookieUtil.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/security/util/CookieUtil.java
@@ -37,7 +37,7 @@ public class CookieUtil {
 
     // Refresh Token 쿠키 삭제 (로그아웃 시)
     public void deleteRefreshCookie(HttpServletResponse response) {
-        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, null)
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
                 .path("/")
                 .maxAge(0)
                 .secure(true)

--- a/src/test/java/com/graduationCapstone/Probe/domain/project/controller/ProjectControllerTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/domain/project/controller/ProjectControllerTest.java
@@ -3,6 +3,7 @@ package com.graduationCapstone.Probe.domain.project.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.graduationCapstone.Probe.domain.github.dto.GithubRepoResponseDto;
 import com.graduationCapstone.Probe.domain.project.dto.*;
+import com.graduationCapstone.Probe.domain.project.entity.ProjectRole;
 import com.graduationCapstone.Probe.domain.project.service.ProjectService;
 import com.graduationCapstone.Probe.domain.user.entity.User;
 import com.graduationCapstone.Probe.domain.user.repository.UserRepository;
@@ -91,10 +92,10 @@ class ProjectControllerTest {
         }
 
         @Test
-        @DisplayName("프로젝트 이름 수정")
+        @DisplayName("프로젝트 이름 수정(OWNER만 가능)")
         void updateProjectName_Success() throws Exception {
             ProjectNameUpdateRequestDto request = new ProjectNameUpdateRequestDto("New Name");
-            given(projectService.updateProjectName(anyLong(), anyString())).willReturn(Mono.empty());
+            given(projectService.updateProjectName(anyLong(), eq(1L), anyString())).willReturn(Mono.empty());
 
             MvcResult result = mockMvc.perform(patch("/api/projects/10/name").with(csrf()).with(authentication(auth))
                             .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(request)))
@@ -104,9 +105,9 @@ class ProjectControllerTest {
         }
 
         @Test
-        @DisplayName("프로젝트 삭제")
+        @DisplayName("프로젝트 삭제(OWNER만 가능)")
         void deleteProject_Success() throws Exception {
-            given(projectService.deleteProject(10L)).willReturn(Mono.empty());
+            given(projectService.deleteProject(eq(10L), eq(1L))).willReturn(Mono.empty());
 
             MvcResult result = mockMvc.perform(delete("/api/projects/10").with(csrf()).with(authentication(auth)))
                     .andExpect(request().asyncStarted()).andReturn();
@@ -171,7 +172,7 @@ class ProjectControllerTest {
         @Test
         @DisplayName("프로젝트 멤버 목록 조회")
         void getProjectMembers_Success() throws Exception {
-            ProjectMemberResponseDto member = new ProjectMemberResponseDto(1L, "testUser", "test@test.com");
+            ProjectMemberResponseDto member = new ProjectMemberResponseDto(1L, "testUser", "test@test.com", ProjectRole.OWNER);
             given(projectService.getProjectMembers(10L)).willReturn(Mono.just(List.of(member)));
 
             MvcResult result = mockMvc.perform(get("/api/projects/10/members").with(authentication(auth)))
@@ -179,7 +180,8 @@ class ProjectControllerTest {
 
             mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$[0].username").value("testUser"));
+                    .andExpect(jsonPath("$[0].username").value("testUser"))
+                    .andExpect(jsonPath("[0].role").value("OWNER"));
         }
 
         @Test
@@ -197,7 +199,7 @@ class ProjectControllerTest {
         @DisplayName("프로젝트 레포지토리 목록 변경")
         void updateProjectRepos_Success() throws Exception {
             ProjectRepoUpdateRequestDto request = new ProjectRepoUpdateRequestDto(List.of(100L));
-            given(projectService.updateProjectRepos(anyLong(), anyList())).willReturn(Mono.empty());
+            given(projectService.updateProjectRepos(eq(10L), eq(1L), anyList())).willReturn(Mono.empty());
 
             MvcResult result = mockMvc.perform(put("/api/projects/10/repos").with(csrf()).with(authentication(auth))
                             .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(request)))

--- a/src/test/java/com/graduationCapstone/Probe/domain/project/controller/ProjectControllerTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/domain/project/controller/ProjectControllerTest.java
@@ -172,7 +172,7 @@ class ProjectControllerTest {
         @Test
         @DisplayName("프로젝트 멤버 목록 조회")
         void getProjectMembers_Success() throws Exception {
-            ProjectMemberResponseDto member = new ProjectMemberResponseDto(1L, "testUser", "test@test.com", ProjectRole.OWNER);
+            ProjectMemberResponseDto member = new ProjectMemberResponseDto(1L, "testUser", "test@test.com", "http://other-image.com", ProjectRole.OWNER);
             given(projectService.getProjectMembers(10L)).willReturn(Mono.just(List.of(member)));
 
             MvcResult result = mockMvc.perform(get("/api/projects/10/members").with(authentication(auth)))
@@ -181,7 +181,8 @@ class ProjectControllerTest {
             mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$[0].username").value("testUser"))
-                    .andExpect(jsonPath("[0].role").value("OWNER"));
+                    .andExpect(jsonPath("$[0].profileImageUrl").value("http://other-image.com"))
+                    .andExpect(jsonPath("$[0].role").value("OWNER"));
         }
 
         @Test
@@ -226,7 +227,7 @@ class ProjectControllerTest {
     @Test
     @DisplayName("사용자 검색")
     void searchUsers_Success() throws Exception {
-        UserSearchResponseDto user = new UserSearchResponseDto(2L, "other", "other@test.com");
+        UserSearchResponseDto user = new UserSearchResponseDto(2L, "other", "other@test.com", "http://other-image.com");
         given(projectService.searchUsers(anyString(), any(User.class))).willReturn(Flux.just(user));
 
         MvcResult result = mockMvc.perform(get("/api/projects/users/search").param("keyword", "other").with(authentication(auth)))
@@ -234,6 +235,7 @@ class ProjectControllerTest {
 
         mockMvc.perform(asyncDispatch(result))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].username").value("other"));
+                .andExpect(jsonPath("$[0].username").value("other"))
+                .andExpect(jsonPath("$[0].profileImageUrl").value("http://other-image.com"));
     }
 }

--- a/src/test/java/com/graduationCapstone/Probe/domain/project/repository/ProjectMemberRepositoryTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/domain/project/repository/ProjectMemberRepositoryTest.java
@@ -1,0 +1,99 @@
+package com.graduationCapstone.Probe.domain.project.repository;
+
+import com.graduationCapstone.Probe.domain.project.entity.Project;
+import com.graduationCapstone.Probe.domain.project.entity.ProjectMember;
+import com.graduationCapstone.Probe.domain.project.entity.ProjectRole;
+import com.graduationCapstone.Probe.domain.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class ProjectMemberRepositoryTest {
+
+    @Autowired
+    private ProjectMemberRepository projectMemberRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    private User user;
+    private Project project;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .username("tester")
+                .email("test@test.com")
+                .githubId("1234")
+                .build();
+        em.persist(user);
+
+        project = Project.builder()
+                .projectName("Test Project")
+                .build();
+        em.persist(project);
+
+        ProjectMember member = ProjectMember.builder()
+                .project(project)
+                .user(user)
+                .role(ProjectRole.OWNER)
+                .build();
+        em.persist(member);
+
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("OWNER 권한 확인 쿼리 테스트")
+    void existsByProjectIdAndUserIdAndRole_Test() {
+        // Given (setUp에서 이미 OWNER로 저장)
+
+        // When
+        boolean isOwner = projectMemberRepository.existsByProjectIdAndUserIdAndRole(
+                project.getId(), user.getId(), ProjectRole.OWNER);
+
+        boolean isMember = projectMemberRepository.existsByProjectIdAndUserIdAndRole(
+                project.getId(), user.getId(), ProjectRole.MEMBER);
+
+        // Then
+        assertThat(isOwner).isTrue();  // OWNER이므로 true
+        assertThat(isMember).isFalse(); // MEMBER가 아니므로 false
+    }
+
+    @Test
+    @DisplayName("프로젝트 ID와 유저 ID로 멤버 조회 (FETCH JOIN 확인)")
+    void findByProjectIdAndUserId_Test() {
+        // When
+        Optional<ProjectMember> result = projectMemberRepository.findByProjectIdAndUserId(
+                project.getId(), user.getId());
+
+        // Then
+        assertThat(result).isPresent();
+        assertThat(result.get().getUser().getUsername()).isEqualTo("tester");
+        assertThat(result.get().getRole()).isEqualTo(ProjectRole.OWNER);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유저나 프로젝트 조회 시 false 반환")
+    void exists_Fail_Test() {
+        // When
+        boolean invalidUser = projectMemberRepository.existsByProjectIdAndUserIdAndRole(
+                project.getId(), 999L, ProjectRole.OWNER);
+
+        boolean invalidProject = projectMemberRepository.existsByProjectIdAndUserIdAndRole(
+                999L, user.getId(), ProjectRole.OWNER);
+
+        // Then
+        assertThat(invalidUser).isFalse();
+        assertThat(invalidProject).isFalse();
+    }
+}

--- a/src/test/java/com/graduationCapstone/Probe/domain/project/repository/ProjectMemberRepositoryTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/domain/project/repository/ProjectMemberRepositoryTest.java
@@ -33,6 +33,7 @@ class ProjectMemberRepositoryTest {
                 .username("tester")
                 .email("test@test.com")
                 .githubId("1234")
+                .profileImageUrl("https://github.com/avatar.png")
                 .build();
         em.persist(user);
 

--- a/src/test/java/com/graduationCapstone/Probe/domain/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/domain/project/service/ProjectServiceTest.java
@@ -6,6 +6,7 @@ import com.graduationCapstone.Probe.domain.github.repository.GithubRepoRepositor
 import com.graduationCapstone.Probe.domain.project.dto.*;
 import com.graduationCapstone.Probe.domain.project.entity.Project;
 import com.graduationCapstone.Probe.domain.project.entity.ProjectMember;
+import com.graduationCapstone.Probe.domain.project.entity.ProjectRole;
 import com.graduationCapstone.Probe.domain.project.repository.ProjectMemberRepository;
 import com.graduationCapstone.Probe.domain.project.repository.ProjectRepoRepository;
 import com.graduationCapstone.Probe.domain.project.repository.ProjectRepository;
@@ -90,13 +91,17 @@ class ProjectServiceTest {
 
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.delete(anyString())).willReturn(Mono.just(true));
+
+        // 기본적으로 권한 체크 통과하도록 함(필요한 테스트에서만 재정의)
+        given(projectMemberRepository.existsByProjectIdAndUserIdAndRole(anyLong(), anyLong(), eq(ProjectRole.OWNER)))
+                .willReturn(true);
     }
 
     @Nested
     @DisplayName("프로젝트 CRUD 테스트")
     class ProjectCrud {
         @Test
-        @DisplayName("프로젝트 생성")
+        @DisplayName("프로젝트 생성(생성자는 OWNER가 된다)")
         void createProject_Success() {
             String requestName = "New Project";
             ProjectCreateRequestDto request = new ProjectCreateRequestDto(requestName, List.of());
@@ -109,8 +114,10 @@ class ProjectServiceTest {
 
             ArgumentCaptor<Project> projectCaptor = ArgumentCaptor.forClass(Project.class);
             verify(projectRepository, times(1)).save(projectCaptor.capture());
+
             Project capturedProject = projectCaptor.getValue();
-            assertThat(capturedProject.getProjectName()).isEqualTo(requestName);
+            ProjectMember creator = capturedProject.getMembers().iterator().next();
+            assertThat(creator.getRole()).isEqualTo(ProjectRole.OWNER);
         }
 
         @Test
@@ -126,19 +133,32 @@ class ProjectServiceTest {
         }
 
         @Test
-        @DisplayName("프로젝트 이름 수정")
+        @DisplayName("프로젝트 이름 수정(OWNER만 가능)")
         void updateName_Success() {
             given(projectRepository.findById(10L)).willReturn(Optional.of(testProject));
-            StepVerifier.create(projectService.updateProjectName(10L, "New Name")).verifyComplete();
+            StepVerifier.create(projectService.updateProjectName(10L, 1L, "New Name")).verifyComplete();
             assertThat(testProject.getProjectName()).isEqualTo("New Name");
         }
 
         @Test
-        @DisplayName("프로젝트 삭제")
+        @DisplayName("프로젝트 삭제(OWNER만 가능)")
         void delete_Success() {
             given(projectRepository.existsById(10L)).willReturn(true);
-            StepVerifier.create(projectService.deleteProject(10L)).verifyComplete();
+            StepVerifier.create(projectService.deleteProject(10L, 1L)).verifyComplete();
             verify(projectRepository).deleteById(10L);
+        }
+
+        @Test
+        @DisplayName("프로젝트 삭제 실패(OWNER가 아닌 경우)")
+        void delete_Fail_NotOwner() {
+            // OWNER가 아니라고 가정
+            given(projectMemberRepository.existsByProjectIdAndUserIdAndRole(10L, 2L, ProjectRole.OWNER))
+                    .willReturn(false);
+
+            StepVerifier.create(projectService.deleteProject(10L, 2L))
+                    .expectErrorMatches(e -> e instanceof CustomException &&
+                            ((CustomException) e).getErrorCode() == ErrorCode.NOT_PROJECT_OWNER)
+                    .verify();
         }
     }
 
@@ -161,7 +181,7 @@ class ProjectServiceTest {
         }
 
         @Test
-        @DisplayName("초대 수락")
+        @DisplayName("초대 수락(초대를 수락한 새로운 멤버는 MEMBER 권한을 가진다")
         void accept_Success() throws Exception {
             InviteTokenInfo info = new InviteTokenInfo(10L, "test@test.com");
             given(valueOperations.get(anyString())).willReturn(Mono.just("json"));
@@ -170,7 +190,14 @@ class ProjectServiceTest {
             given(userRepository.findByEmail("test@test.com")).willReturn(Optional.of(testUser));
 
             StepVerifier.create(projectService.acceptInvitationByToken("token")).verifyComplete();
-            verify(projectRepository).save(any(Project.class));
+
+            // 추가된 멤버의 권한이 MEMBER인지 검증
+            ArgumentCaptor<Project> projectCaptor = ArgumentCaptor.forClass(Project.class);
+            verify(projectRepository).save(projectCaptor.capture());
+            Project capturedProject = projectCaptor.getValue();
+            boolean hasMemberRole = capturedProject.getMembers().stream()
+                    .anyMatch(m -> m.getRole() == ProjectRole.MEMBER);
+            assertThat(hasMemberRole).isTrue();
         }
 
         @Test
@@ -185,13 +212,25 @@ class ProjectServiceTest {
         }
 
         @Test
-        @DisplayName("멤버 삭제(스스로 나가기)")
+        @DisplayName("멤버 삭제(스스로 나가기, 권한이 MEMBER일 경우)")
         void removeMember_Success() {
-            ProjectMember member = ProjectMember.builder().build();
+            ProjectMember member = ProjectMember.builder().role(ProjectRole.MEMBER).build();
             given(projectMemberRepository.findByProjectIdAndUserId(10L, 1L)).willReturn(Optional.of(member));
 
             StepVerifier.create(projectService.removeMember(10L, 1L)).verifyComplete();
             verify(projectMemberRepository).delete(member);
+        }
+
+        @Test
+        @DisplayName("멤버 삭제 실패(OWNER는 스스로 나갈 수 없음)")
+        void removeMember_Fail_Owner() {
+            ProjectMember member = ProjectMember.builder().role(ProjectRole.OWNER).build();
+            given(projectMemberRepository.findByProjectIdAndUserId(10L, 1L)).willReturn(Optional.of(member));
+
+            StepVerifier.create(projectService.removeMember(10L, 1L))
+                    .expectErrorMatches(e -> e instanceof CustomException &&
+                            ((CustomException) e).getErrorCode() == ErrorCode.OWNER_CANNOT_LEAVE)
+                    .verify();
         }
 
         @Test
@@ -217,7 +256,7 @@ class ProjectServiceTest {
             GithubRepo repo = GithubRepo.builder().id(50L).build();
             given(githubRepoRepository.findAllById(anyList())).willReturn(List.of(repo));
 
-            StepVerifier.create(projectService.updateProjectRepos(10L, List.of(50L))).verifyComplete();
+            StepVerifier.create(projectService.updateProjectRepos(10L, 1L, List.of(50L))).verifyComplete();
             verify(projectRepository).save(testProject);
         }
 

--- a/src/test/java/com/graduationCapstone/Probe/domain/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/domain/project/service/ProjectServiceTest.java
@@ -79,7 +79,12 @@ class ProjectServiceTest {
 
     @BeforeEach
     void setUp() {
-        testUser = User.builder().id(1L).email("test@test.com").username("tester").build();
+        testUser = User.builder()
+                .id(1L)
+                .email("test@test.com")
+                .username("tester")
+                .profileImageUrl("http://tester-image.com")
+                .build();
         testProject = Project.builder()
                 .id(10L)
                 .projectName("Probe Project")
@@ -242,6 +247,28 @@ class ProjectServiceTest {
 
             StepVerifier.create(projectService.searchUsers("keyword", testUser))
                     .assertNext(res -> assertThat(res.username()).isEqualTo("other"))
+                    .verifyComplete();
+        }
+
+        @Test
+        @DisplayName("특정 프로젝트 멤버 목록 조회 시 이미지와 권한이 포함된다")
+        void getProjectMembers_Success() {
+            // given
+            ProjectMember member = ProjectMember.builder()
+                    .user(testUser)
+                    .role(ProjectRole.OWNER)
+                    .build();
+            testProject.addMember(member);
+
+            given(projectRepository.findByIdWithMembers(10L)).willReturn(Optional.of(testProject));
+
+            // when & then
+            StepVerifier.create(projectService.getProjectMembers(10L))
+                    .assertNext(list -> {
+                        assertThat(list.get(0).username()).isEqualTo("tester");
+                        assertThat(list.get(0).profileImageUrl()).isEqualTo("http://tester-image.com"); // 💡 이미지 확인
+                        assertThat(list.get(0).role()).isEqualTo(ProjectRole.OWNER); // 💡 역할 확인
+                    })
                     .verifyComplete();
         }
     }

--- a/src/test/java/com/graduationCapstone/Probe/domain/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/domain/project/service/ProjectServiceTest.java
@@ -121,6 +121,7 @@ class ProjectServiceTest {
             verify(projectRepository, times(1)).save(projectCaptor.capture());
 
             Project capturedProject = projectCaptor.getValue();
+            assertThat(capturedProject.getProjectName()).isEqualTo(requestName);
             ProjectMember creator = capturedProject.getMembers().iterator().next();
             assertThat(creator.getRole()).isEqualTo(ProjectRole.OWNER);
         }

--- a/src/test/java/com/graduationCapstone/Probe/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/domain/user/controller/UserControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -20,10 +21,8 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @ExtendWith(MockitoExtension.class)
 class UserControllerTest {
@@ -45,6 +44,7 @@ class UserControllerTest {
                 .id(1L)
                 .username("testUser")
                 .email("test@email.com")
+                .profileImageUrl("http://image.com")
                 .githubId("12345")
                 .build();
 
@@ -71,12 +71,17 @@ class UserControllerTest {
     @Test
     @DisplayName("내 정보 조회: 로그인된 사용자 정보를 JSON으로 반환합니다.")
     void getMe_Success() throws Exception {
-        // when & then
-        mockMvc.perform(get("/api/user/me")
+        MvcResult mvcResult = mockMvc.perform(get("/api/user/me")
                         .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(request().asyncStarted()) // 비동기 작업이 시작되었는지 확인
+                .andReturn();
+        // when & then
+        mockMvc.perform(asyncDispatch(mvcResult))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.username").value("testUser"))
-                .andExpect(jsonPath("$.email").value("test@email.com"));
+                .andExpect(jsonPath("$.email").value("test@email.com"))
+                .andExpect(jsonPath("$.profileImageUrl").value("http://image.com")) // 💡 이미지 포함 확인
+                .andExpect(jsonPath("$.githubId").doesNotExist());
     }
 
     @Test

--- a/src/test/java/com/graduationCapstone/Probe/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/domain/user/service/UserServiceTest.java
@@ -38,22 +38,24 @@ class UserServiceTest {
     private RefreshTokenRepository refreshTokenRepository;
 
     // 테스트용 DTO
-    private OAuth2ResponseDto createDto(String githubId, String username, String email) {
+    private OAuth2ResponseDto createDto(String githubId, String username, String email, String profileImageUrl) {
         return new OAuth2ResponseDto(
                 Collections.emptyMap(),
                 "id",
                 githubId,
                 username,
-                email
+                email,
+                profileImageUrl
         );
     }
 
     // 테스트용 User Entity
-    private User createUser(String githubId, String username, String email, boolean isDeleted) {
+    private User createUser(String githubId, String username, String email, String profileImageUrl, boolean isDeleted) {
         return User.builder()
                 .githubId(githubId)
                 .username(username)
                 .email(email)
+                .profileImageUrl(profileImageUrl)
                 .deleted(isDeleted)
                 .build();
     }
@@ -63,7 +65,7 @@ class UserServiceTest {
     void saveOrUpdateUser_NewUser() {
         // given
         String githubId = "new-github-id";
-        OAuth2ResponseDto dto = createDto(githubId, "new-user", "new@test.com");
+        OAuth2ResponseDto dto = createDto(githubId, "new-user", "new@test.com", "http://new-image.com");
 
         // DB에 해당 githubId가 없음
         given(userRepository.findByGithubId(githubId)).willReturn(Optional.empty());
@@ -84,10 +86,10 @@ class UserServiceTest {
         String oldName = "old-name";
         String newName = "updated-name";
 
-        OAuth2ResponseDto dto = createDto(githubId, newName, "email@test.com");
+        OAuth2ResponseDto dto = createDto(githubId, newName, "email@test.com", "http://new-image.com");
 
         // 기존 유저 (deleted = false)
-        User existingUser = createUser(githubId, oldName, "email@test.com", false);
+        User existingUser = createUser(githubId, oldName, "email@test.com", "http://new-image.com", false);
         given(userRepository.findByGithubId(githubId)).willReturn(Optional.of(existingUser));
 
         // when
@@ -96,6 +98,8 @@ class UserServiceTest {
         // then
         // 객체의 username이 변경되었는지 확인 (updateUsername 동작 검증)
         assertThat(existingUser.getUsername()).isEqualTo(newName);
+        // 객체의 프로필 이미지가 변경되었는지 확인
+        assertThat(existingUser.getProfileImageUrl()).isEqualTo("http://new-image.com");
         // 탈퇴 상태가 아닌지 확인
         assertThat(existingUser.isDeleted()).isFalse();
         // save 호출 확인
@@ -108,10 +112,10 @@ class UserServiceTest {
         // given
         String githubId = "deleted-id";
         String newName = "return-user";
-        OAuth2ResponseDto dto = createDto(githubId, newName, "email@test.com");
+        OAuth2ResponseDto dto = createDto(githubId, newName, "email@test.com", "http://new-image.com");
 
         // 기존 유저 (deleted = true)
-        User deletedUser = createUser(githubId, "old-name", "email@test.com", true);
+        User deletedUser = createUser(githubId, "old-name", "email@test.com", "http://new-image.com",true);
 
         // 실행 전 상태 확인
         assertThat(deletedUser.isDeleted()).isTrue();
@@ -126,6 +130,8 @@ class UserServiceTest {
         assertThat(deletedUser.isDeleted()).isFalse();
         // 닉네임 업데이트 확인
         assertThat(deletedUser.getUsername()).isEqualTo(newName);
+        // 프로필 이미지 업데이트 확인
+        assertThat(deletedUser.getProfileImageUrl()).isEqualTo("http://new-image.com");
         // save 호출 확인
         verify(userRepository).save(deletedUser);
     }
@@ -136,7 +142,7 @@ class UserServiceTest {
         // given
         Long userId = 1L;
         // 활성 상태 유저 생성
-        User user = createUser("gh-id", "user", "email", false);
+        User user = createUser("gh-id", "user", "email", "http://new-image.com",false);
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
 

--- a/src/test/java/com/graduationCapstone/Probe/global/security/oauth/service/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/global/security/oauth/service/CustomOAuth2UserServiceTest.java
@@ -19,6 +19,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -71,22 +72,31 @@ class CustomOAuth2UserServiceTest {
         OAuth2UserRequest userRequest = new OAuth2UserRequest(clientRegistration, accessToken);
 
         // 외부 API(Delegate)가 반환할 가짜 유저 정보 설정
-        Map<String, Object> attributes = Map.of(
-                "id", 12345,
-                "login", "test-user",
-                "email", "test@example.com"
-        );
+        Map<String, Object> originAttributes = new HashMap<>();
+        originAttributes.put("id", 12345);
+        originAttributes.put("login", "test-user");
+        originAttributes.put("email", "test@example.com");
+        originAttributes.put("avatar_url", "http://github-image.com/avatar.png");
+
         OAuth2User mockOAuth2User = new DefaultOAuth2User(
-                Collections.emptySet(), attributes, userNameAttributeName);
+                Collections.emptySet(), originAttributes, userNameAttributeName);
 
         // delegate.loadUser()가 호출되면 가짜 유저를 반환
         given(mockDelegate.loadUser(any(OAuth2UserRequest.class))).willReturn(mockOAuth2User);
 
+        Map<String, Object> expectedAttributes = new HashMap<>(originAttributes);
+        expectedAttributes.put("githubAccessToken", "access-token");
+
         // OAuth2Util 변환 결과 설정
         OAuth2ResponseDto responseDto = new OAuth2ResponseDto(
-                attributes, userNameAttributeName, "12345", "test-user", "test@example.com");
+                originAttributes,
+                userNameAttributeName,
+                "12345",
+                "test-user",
+                "test@example.com",
+                "http://github-image.com/avatar.png");
 
-        given(oAuth2Util.getOAuth2Response(eq(registrationId), eq(userNameAttributeName), eq(attributes)))
+        given(oAuth2Util.getOAuth2Response(eq(registrationId), eq(userNameAttributeName), eq(originAttributes)))
                 .willReturn(responseDto);
 
         com.graduationCapstone.Probe.domain.user.entity.User mockUserEntity =
@@ -95,6 +105,7 @@ class CustomOAuth2UserServiceTest {
                         .githubId("12345")
                         .username("test-user")
                         .email("test@example.com")
+                        .profileImageUrl("http://github-image.com/avatar.png")
                         .build();
 
         given(userService.saveOrUpdateUser(any(OAuth2ResponseDto.class)))
@@ -109,7 +120,7 @@ class CustomOAuth2UserServiceTest {
 
         // 반환된 OAuth2User 객체가 정상적인지 검증
         assertThat(result).isNotNull();
-        assertThat(result.getAttributes()).isEqualTo(attributes);
+        assertThat(result.getAttributes()).isEqualTo(expectedAttributes);
         assertThat(result.getName()).isEqualTo("12345"); // userNameAttributeName("id") 값
     }
 }

--- a/src/test/java/com/graduationCapstone/Probe/global/security/oauth/util/OAuth2UtilTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/global/security/oauth/util/OAuth2UtilTest.java
@@ -32,6 +32,7 @@ class OAuth2UtilTest {
         attributes.put("id", 12345);
         attributes.put("login", "testuser");
         attributes.put("email", "test@example.com");
+        attributes.put("avatar_url", "https://github.com/avatar.png");
 
         // when
         OAuth2ResponseDto result = oAuth2Util.getOAuth2Response(registrationId, userNameAttributeName, attributes);
@@ -41,6 +42,7 @@ class OAuth2UtilTest {
         assertThat(result.githubId()).isEqualTo("12345");
         assertThat(result.username()).isEqualTo("testuser");
         assertThat(result.email()).isEqualTo("test@example.com");
+        assertThat(result.profileImageUrl()).isEqualTo("https://github.com/avatar.png");
     }
 
     @Test


### PR DESCRIPTION
## 📝 PR 설명
프로젝트 단위에서의 OWNER/MEMBER 권한 체계를 도입하였습니다.
GitHub 프로필 이미지 연동 기능 추가하고, 내 정보 조회 시 닉네임, 이메일, 프로필 이미지를 반환하도록 수정하였습니다.
유지보수성을 높이기 위한 서비스 전반에 로그 시스템을 구축하였습니다.

## 🛠 주요 변경 사항
- 권한 체계 도입: ProjectRole (OWNER, MEMBER)을 추가하고 프로젝트 수정/삭제/레포지토리 관리 시 소유자 권한 검증 로직(validateOwner)을 적용했습니다.
- GitHub 프로필 연동: User 및 Project 엔티티에 profileImageUrl 필드를 추가하고, OAuth2 로그인 시 GitHub의 avatar_url을 자동으로 동기화하도록 구현했습니다.
- 내 정보 조회 시 반환 값 수정: /api/user/me API 요청 시 닉네임, 이메일, 프로필 이미지를 반환하도록 수정하였습니다.
- 로그 시스템 구축: 모든 서비스 레이어에 @Slf4j를 적용하여 주요 비즈니스 흐름과 에러 발생 지점에 대한 추적 기능을 강화했습니다.
- 테스트 코드 보완: 권한 및 이미지 업데이트에 대한 검증 케이스를 추가했습니다.

## 🧪 테스트 체크리스트
- 권한 체계(OWNER/MEMBER) 검증
- [ ] 프로젝트 OWNER 권한을 가진 사용자가 프로젝트 이름 수정, 삭제, 레포지토리 관리를 수행할 수 있는지 확인
- [ ] 프로젝트 MEMBER 권한을 가진 사용자가 상기 기능을 시도할 때 NOT_PROJECT_OWNER 예외가 발생하는지 확인
- [ ]  소유자가 아닌 유저가 접근 시 403 Forbidden 또는 커스텀 에러 코드가 정상 반환되는지 확인

- GitHub 프로필 이미지 연동 및 동기화
- [ ] GitHub OAuth2 로그인 시 avatar_url이 User 엔티티의 profileImageUrl 필드에 정상적으로 저장/업데이트되는지 확인
- [ ] [기존 사용자가 GitHub에서 프로필 사진을 변경한 후 재로그인했을 때 최신 URL로 갱신되는지 확인

- 내 정보 조회(/api/user/me) API 검증
- [ ] API 호출 시 닉네임(username), 이메일(email), 프로필 이미지(profileImageUrl) 3가지 필드가 JSON 응답에 포함되는지 확인
- [ ] 엔티티 직접 반환 방식에서 DTO 반환 방식으로 전환 후, 순환 참조로 인한 500 Internal Server Error가 해결되었는지 확인

- 로그 및 테스트 코드
- [ ] 주요 비즈니스 로직(프로젝트 생성, 멤버 초대 등) 수행 시 콘솔에 INFO 및 DEBUG 로그가 의도한 형식으로 출력되는지 확인
- [ ] 예외 발생 시 에러 로그와 스택 트레이스가 남는지 확인
- [ ] 새롭게 추가된 권한 검증 및 이미지 업데이트 관련 JUnit5/StepVerifier 테스트 케이스가 모두 통과(Pass)하는지 확인

## 📸 스크린샷 또는 비디오

## ➕ 추가 사항
- 로그 레벨은 중요 비즈니스 단계는 info, 상세 데이터 흐름은 debug, 예외 발생 시에는 error로 구분하여 적용했습니다.

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다
- [ ] 불필요한 코드를 제거했습니다
- [ ] 주석 처리를 필요한 만큼 하였습니다.
- [ ] PR 제목 또는 설명에 Jira 이슈 키를 포함했습니다

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
