### PR TITLE
[Cst-97] fix: 쿠키 관리 체계 개선

### DIFF
--- a/src/main/java/com/graduationCapstone/Probe/domain/user/controller/UserController.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/user/controller/UserController.java
@@ -5,6 +5,8 @@ import com.graduationCapstone.Probe.domain.user.entity.User;
 import com.graduationCapstone.Probe.domain.user.service.UserService;
 import com.graduationCapstone.Probe.global.exception.ErrorCode;
 import com.graduationCapstone.Probe.global.exception.handler.CustomException;
+import com.graduationCapstone.Probe.global.security.util.CookieUtil;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -28,6 +30,7 @@ import reactor.core.publisher.Mono;
 public class UserController {
 
     private final UserService userService;
+    private final CookieUtil cookieUtil;
 
     @Operation(summary = "내 정보 조회", description = "유효한 Access Token으로 현재 로그인된 사용자(User)의 닉네임, 이메일, 프로필 이미지를 조회합니다.")
     @ApiResponses({
@@ -60,9 +63,14 @@ public class UserController {
             @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음 (논리적 삭제 과정 중)")
     })
     @DeleteMapping("/me")
-    public ResponseEntity<Void> delete(@AuthenticationPrincipal User user) {
-        Long userId = user.getId();
-        userService.deleteUser(userId);
-        return ResponseEntity.noContent().build();
+    public Mono<ResponseEntity<Void>> delete(
+            @AuthenticationPrincipal User user,
+            HttpServletResponse response) {
+        if (user == null) throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+
+        return Mono.fromRunnable(() -> {
+            userService.deleteUser(user.getId());
+            cookieUtil.deleteAllCookies(response);
+        }).then(Mono.just(ResponseEntity.noContent().build()));
     }
 }

--- a/src/main/java/com/graduationCapstone/Probe/global/config/SecurityConfig.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/config/SecurityConfig.java
@@ -4,8 +4,10 @@ import com.graduationCapstone.Probe.global.security.jwt.handler.JwtAuthenticatio
 import com.graduationCapstone.Probe.global.security.oauth.handler.OAuth2LoginSuccessHandler;
 import com.graduationCapstone.Probe.global.security.jwt.filter.JwtFilter;
 import com.graduationCapstone.Probe.global.security.oauth.service.CustomOAuth2UserService;
+import com.graduationCapstone.Probe.global.security.util.CookieUtil;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.DispatcherType;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -54,6 +56,19 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
+                .logout(logout -> logout
+                        .logoutUrl("/api/auth/logout")
+                        .deleteCookies(CookieUtil.JSESSIONID_COOKIE_NAME, CookieUtil.ACCESS_TOKEN_COOKIE_NAME, CookieUtil.REFRESH_TOKEN_COOKIE_NAME)
+                        .invalidateHttpSession(true)
+                        .clearAuthentication(true)
+                        .logoutSuccessHandler((request, response, authentication) -> {
+                            response.setStatus(HttpServletResponse.SC_OK);
+                            response.setCharacterEncoding("UTF-8");
+                            response.setContentType("application/json");
+                            response.getWriter().write("{\"message\":\"로그아웃 성공\"}");
+                        })
+                )
+
                 .authorizeHttpRequests(auth -> auth
                         .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
                         // 모든 경로에 대해 인증 없이 허용
@@ -64,6 +79,7 @@ public class SecurityConfig {
                                 "/oauth2/**",
                                 "/login/**",
                                 "/api/auth/reissue",
+                                "/api/auth/logout",
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
                                 "/api/projects/accept",

--- a/src/main/java/com/graduationCapstone/Probe/global/config/SecurityConfig.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/config/SecurityConfig.java
@@ -56,19 +56,6 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
-                .logout(logout -> logout
-                        .logoutUrl("/api/auth/logout")
-                        .deleteCookies(CookieUtil.JSESSIONID_COOKIE_NAME, CookieUtil.ACCESS_TOKEN_COOKIE_NAME, CookieUtil.REFRESH_TOKEN_COOKIE_NAME)
-                        .invalidateHttpSession(true)
-                        .clearAuthentication(true)
-                        .logoutSuccessHandler((request, response, authentication) -> {
-                            response.setStatus(HttpServletResponse.SC_OK);
-                            response.setCharacterEncoding("UTF-8");
-                            response.setContentType("application/json");
-                            response.getWriter().write("{\"message\":\"로그아웃 성공\"}");
-                        })
-                )
-
                 .authorizeHttpRequests(auth -> auth
                         .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
                         // 모든 경로에 대해 인증 없이 허용

--- a/src/main/java/com/graduationCapstone/Probe/global/security/login/controller/LoginController.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/security/login/controller/LoginController.java
@@ -31,7 +31,7 @@ public class LoginController {
     @Operation(summary = "Access Token 재발급", description = " 쿠키의 Refresh Token을 검증하여 새로운 Access/Refresh Token을 모두 쿠키로 재발급합니다.")
     @ApiResponses({
             @ApiResponse(
-                    responseCode = "200",
+                    responseCode = "204",
                     description = "토큰 재발급 성공",
                     content = @Content // Body 없음
             ),
@@ -39,7 +39,7 @@ public class LoginController {
             @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
     })
     @PostMapping("/reissue")
-    public ResponseEntity<TokenResponseDto> reissue(
+    public ResponseEntity<Void> reissue(
             HttpServletRequest request,
             HttpServletResponse response
     ) {

--- a/src/main/java/com/graduationCapstone/Probe/global/security/login/controller/LoginController.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/security/login/controller/LoginController.java
@@ -2,7 +2,6 @@ package com.graduationCapstone.Probe.global.security.login.controller;
 
 import com.graduationCapstone.Probe.global.exception.ErrorCode;
 import com.graduationCapstone.Probe.global.exception.handler.CustomException;
-import com.graduationCapstone.Probe.global.security.login.dto.TokenResponseDto;
 import com.graduationCapstone.Probe.global.security.login.service.LoginService;
 import com.graduationCapstone.Probe.global.security.util.CookieUtil;
 import jakarta.servlet.http.HttpServletRequest;
@@ -16,8 +15,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
 @Tag(name = "인증 관리 (Auth)", description = "JWT 토큰 재발급 및 로그아웃 처리")
 @RestController

--- a/src/main/java/com/graduationCapstone/Probe/global/security/login/controller/LoginController.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/security/login/controller/LoginController.java
@@ -49,7 +49,7 @@ public class LoginController {
             throw new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
         }
 
-        TokenResponseDto tokenResponseDto = loginService.reissue(refreshToken);
+        TokenResponseDto tokenResponseDto = loginService.reissue(refreshToken, response);
 
         cookieUtil.addRefreshCookie(response, tokenResponseDto.refreshToken());
 
@@ -65,19 +65,14 @@ public class LoginController {
             @ApiResponse(responseCode = "204", description = "로그아웃(Refresh Token 삭제) 성공"),
             @ApiResponse(responseCode = "401", description = "Access Token이 유효하지 않거나 누락됨")
     })
-    @SecurityRequirement(name = "BearerAuth") // JWT 인증 필요
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(
-            @RequestHeader("Authorization") String accessToken,
+            HttpServletRequest request,
             HttpServletResponse response
     ) {
-        if (accessToken == null || !accessToken.startsWith("Bearer ")) {
-            throw new CustomException(ErrorCode.INVALID_TOKEN);
-        }
 
-        String token = accessToken.substring("Bearer ".length());
-        loginService.logout(token);
-        cookieUtil.deleteRefreshCookie(response);
+        loginService.logout(request, response);
+
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/graduationCapstone/Probe/global/security/login/controller/LoginController.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/security/login/controller/LoginController.java
@@ -28,12 +28,12 @@ public class LoginController {
     private final LoginService loginService;
     private final CookieUtil cookieUtil;
 
-    @Operation(summary = "Access Token 재발급", description = "만료된 Access Token을 Refresh Token을 통해 새롭게 발급 받습니다.")
+    @Operation(summary = "Access Token 재발급", description = " 쿠키의 Refresh Token을 검증하여 새로운 Access/Refresh Token을 모두 쿠키로 재발급합니다.")
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
-                    description = "새로운 Access Token 및 Refresh Token 발급 성공",
-                    content = @Content(schema = @Schema(implementation = TokenResponseDto.class))
+                    description = "토큰 재발급 성공",
+                    content = @Content // Body 없음
             ),
             @ApiResponse(responseCode = "401", description = "Refresh Token이 유효하지 않거나 만료됨"),
             @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
@@ -49,21 +49,16 @@ public class LoginController {
             throw new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
         }
 
-        TokenResponseDto tokenResponseDto = loginService.reissue(refreshToken, response);
+        loginService.reissue(refreshToken, response);
 
-        cookieUtil.addRefreshCookie(response, tokenResponseDto.refreshToken());
+        return ResponseEntity.noContent().build();
 
-        return ResponseEntity.ok(new TokenResponseDto(
-                tokenResponseDto.accessToken(),
-                null
-        ));
     }
 
 
-    @Operation(summary = "로그아웃", description = "Refresh Token을 DB에서 삭제하여 토큰 재발급 경로를 차단합니다.")
+    @Operation(summary = "로그아웃", description = "Refresh Token을 DB에서 삭제하고, 브라우저에 저장된 모든 인증 관련 쿠키를 제거합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "로그아웃(Refresh Token 삭제) 성공"),
-            @ApiResponse(responseCode = "401", description = "Access Token이 유효하지 않거나 누락됨")
+            @ApiResponse(responseCode = "204", description = "로그아웃(Refresh Token 삭제) 성공")
     })
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(

--- a/src/main/java/com/graduationCapstone/Probe/global/security/login/service/LoginService.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/security/login/service/LoginService.java
@@ -6,6 +6,9 @@ import com.graduationCapstone.Probe.global.security.jwt.util.JwtUtil;
 import com.graduationCapstone.Probe.global.security.login.dto.TokenResponseDto;
 import com.graduationCapstone.Probe.global.security.login.entity.RefreshToken;
 import com.graduationCapstone.Probe.global.security.login.repository.RefreshTokenRepository;
+import com.graduationCapstone.Probe.global.security.util.CookieUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,12 +22,14 @@ public class LoginService {
 
     private final JwtUtil jwtUtil;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final CookieUtil cookieUtil;
 
     // 토큰 재발급 로직
-    public TokenResponseDto reissue(String refreshToken) {
+    public TokenResponseDto reissue(String refreshToken, HttpServletResponse response) {
         log.info("토큰 재발급 요청 시작");
         if (!jwtUtil.validateToken(refreshToken)) {
             log.warn("토큰 재발급 실패: 유효하지 않은 리프레시 토큰");
+            cookieUtil.deleteRefreshCookie(response);
             throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
@@ -34,6 +39,7 @@ public class LoginService {
                 .orElseThrow(() -> new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
 
         if (!storedToken.getRefreshToken().equals(refreshToken)) {
+            cookieUtil.deleteRefreshCookie(response);
             throw new CustomException(ErrorCode.REFRESH_TOKEN_MISMATCH);
         }
 
@@ -42,14 +48,23 @@ public class LoginService {
 
         storedToken.updateToken(newRefreshToken);
 
+        cookieUtil.addAccessCookie(response, newAccessToken);
+        cookieUtil.addRefreshCookie(response, newRefreshToken);
+
         log.info("토큰 재발급 완료: userId={}", userId);
         return new TokenResponseDto(newAccessToken, newRefreshToken);
     }
 
     // 로그아웃 로직
-    public void logout(String accessToken) {
-        Long userId = jwtUtil.getUserId(accessToken);
-        log.info("로그아웃: userId={}", userId);
-        refreshTokenRepository.deleteByUserId(userId);
+    public void logout(HttpServletRequest request, HttpServletResponse response) {
+        String accessToken = cookieUtil.getCookieValue(request, CookieUtil.ACCESS_TOKEN_COOKIE_NAME);
+
+        if (accessToken != null && jwtUtil.validateToken(accessToken)) {
+            Long userId = jwtUtil.getUserId(accessToken);
+            log.info("로그아웃 DB 처리 시작: userId={}", userId);
+            refreshTokenRepository.deleteByUserId(userId);
+        }
+
+        cookieUtil.deleteAllCookies(response);
     }
 }

--- a/src/main/java/com/graduationCapstone/Probe/global/security/login/service/LoginService.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/security/login/service/LoginService.java
@@ -12,6 +12,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -36,9 +37,14 @@ public class LoginService {
         Long userId = jwtUtil.getUserId(refreshToken); //토큰에서 userId 추출
 
         RefreshToken storedToken = refreshTokenRepository.findByUserId(userId) // User ID로 RefreshToken 값 가져옴
-                .orElseThrow(() -> new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+                .orElseThrow(() -> {
+                    log.warn("토큰 재발급 실패: DB에 리프레시 토큰이 없음 (userId={})", userId);
+                    cookieUtil.deleteRefreshCookie(response);
+                    return new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+                });
 
         if (!storedToken.getRefreshToken().equals(refreshToken)) {
+            log.warn("토큰 재발급 실패: 토큰 불일치 (userId={})", userId);
             cookieUtil.deleteRefreshCookie(response);
             throw new CustomException(ErrorCode.REFRESH_TOKEN_MISMATCH);
         }
@@ -58,13 +64,26 @@ public class LoginService {
     // 로그아웃 로직
     public void logout(HttpServletRequest request, HttpServletResponse response) {
         String accessToken = cookieUtil.getCookieValue(request, CookieUtil.ACCESS_TOKEN_COOKIE_NAME);
+        String refreshToken = cookieUtil.getCookieValue(request, CookieUtil.REFRESH_TOKEN_COOKIE_NAME);
+
+        Long userId = null;
 
         if (accessToken != null && jwtUtil.validateToken(accessToken)) {
-            Long userId = jwtUtil.getUserId(accessToken);
-            log.info("로그아웃 DB 처리 시작: userId={}", userId);
+            userId = jwtUtil.getUserId(accessToken);
+        }
+
+        if (userId == null && refreshToken != null && jwtUtil.validateToken(refreshToken)) {
+            userId = jwtUtil.getUserId(refreshToken);
+        }
+
+        if (userId != null) {
+            log.info("로그아웃 DB 처리 진행: userId={}", userId);
             refreshTokenRepository.deleteByUserId(userId);
+        } else {
+            log.warn("로그아웃 시 유효한 토큰이 없어 DB 삭제를 스킵합니다. (쿠키만 삭제)");
         }
 
         cookieUtil.deleteAllCookies(response);
+        SecurityContextHolder.clearContext(); // 현재 스레드에 남아있을지 모르는 인증 정보 확실히 날림
     }
 }

--- a/src/main/java/com/graduationCapstone/Probe/global/security/util/CookieUtil.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/security/util/CookieUtil.java
@@ -20,35 +20,37 @@ public class CookieUtil {
 
     public static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
     public static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
+    public static final String JSESSIONID_COOKIE_NAME = "JSESSIONID";
 
 
-    // Refresh Token 쿠키 생성
     public void addRefreshCookie(HttpServletResponse response, String refreshToken) {
-        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
-                .path("/")
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("None")
-                .maxAge(refreshTokenExpirationDays * 24 * 60 * 60)
-                .build();
-
-        response.addHeader("Set-Cookie", cookie.toString());
+        addCookie(response, REFRESH_TOKEN_COOKIE_NAME, refreshToken, refreshTokenExpirationDays * 24 * 60 * 60);
     }
 
-    // Refresh Token 쿠키 삭제 (로그아웃 시)
+    public void addAccessCookie(HttpServletResponse response, String accessToken) {
+        addCookie(response, ACCESS_TOKEN_COOKIE_NAME, accessToken, accessTokenExpirationMinutes * 60);
+    }
+
+    /**
+     * 모든 인증 관련 쿠키 일괄 삭제 (로그아웃/탈퇴 시)
+     */
+    public void deleteAllCookies(HttpServletResponse response) {
+        deleteCookie(response, REFRESH_TOKEN_COOKIE_NAME);
+        deleteCookie(response, ACCESS_TOKEN_COOKIE_NAME);
+        deleteCookie(response, JSESSIONID_COOKIE_NAME);
+    }
+
+    /**
+     * 개별 쿠키 삭제 메서드 (필요 시 선택적 사용)
+     */
     public void deleteRefreshCookie(HttpServletResponse response) {
-        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
-                .path("/")
-                .maxAge(0)
-                .secure(true)
-                .sameSite("None")
-                .httpOnly(true)
-                .build();
-
-        response.addHeader("Set-Cookie", cookie.toString());
+        deleteCookie(response, REFRESH_TOKEN_COOKIE_NAME);
     }
 
-    // Request에서 Refresh Token 가져오기
+    public void deleteAccessCookie(HttpServletResponse response) {
+        deleteCookie(response, ACCESS_TOKEN_COOKIE_NAME);
+    }
+
     public String getRefreshTokenFromCookie(HttpServletRequest request) {
         return getCookieValue(request, REFRESH_TOKEN_COOKIE_NAME);
     }
@@ -62,16 +64,26 @@ public class CookieUtil {
                 .orElse(null);
     }
 
-    // Access Token 쿠키 생성
-    public void addAccessCookie(HttpServletResponse response, String accessToken) {
-        ResponseCookie cookie = ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, accessToken)
+    private void addCookie(HttpServletResponse response, String name, String value, long maxAge) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
                 .path("/")
                 .httpOnly(true)
                 .secure(true)
                 .sameSite("None")
-                .maxAge(accessTokenExpirationMinutes * 60)
+                .maxAge(maxAge)
                 .build();
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
 
+    private void deleteCookie(HttpServletResponse response, String name) {
+        ResponseCookie cookie = ResponseCookie.from(name, "")
+                .path("/")
+                .maxAge(0)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .build();
         response.addHeader("Set-Cookie", cookie.toString());
     }
 }
+

--- a/src/test/java/com/graduationCapstone/Probe/global/security/login/controller/LoginControllerTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/global/security/login/controller/LoginControllerTest.java
@@ -20,10 +20,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/com/graduationCapstone/Probe/global/security/login/controller/LoginControllerTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/global/security/login/controller/LoginControllerTest.java
@@ -62,17 +62,13 @@ class LoginControllerTest {
         // 서비스가 재발급을 성공한다고 가정
         given(loginService.reissue(eq(refreshToken), any(HttpServletResponse.class))).willReturn(serviceResponse);
 
-        // CookieUtil이 응답에 쿠키를 추가하는 동작 Mocking
-        doNothing().when(cookieUtil).addRefreshCookie(any(HttpServletResponse.class), eq(newRefreshToken));
-
         // when & then
         mockMvc.perform(post("/api/auth/reissue"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.accessToken").value(newAccessToken)) // Body에는 AT만 있어야 함
                 .andExpect(jsonPath("$.refreshToken").isEmpty()); // Controller에서 RT는 null로 내려줌
 
-        // 쿠키 굽는 메서드가 진짜 호출되었는지 확인
-        verify(cookieUtil).addRefreshCookie(any(HttpServletResponse.class), eq(newRefreshToken));
+        verify(loginService).reissue(eq(refreshToken), any(HttpServletResponse.class));
     }
 
     @Test

--- a/src/test/java/com/graduationCapstone/Probe/global/security/login/controller/LoginControllerTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/global/security/login/controller/LoginControllerTest.java
@@ -60,7 +60,7 @@ class LoginControllerTest {
                 .willReturn(refreshToken);
 
         // 서비스가 재발급을 성공한다고 가정
-        given(loginService.reissue(refreshToken)).willReturn(serviceResponse);
+        given(loginService.reissue(eq(refreshToken), any(HttpServletResponse.class))).willReturn(serviceResponse);
 
         // CookieUtil이 응답에 쿠키를 추가하는 동작 Mocking
         doNothing().when(cookieUtil).addRefreshCookie(any(HttpServletResponse.class), eq(newRefreshToken));
@@ -97,22 +97,14 @@ class LoginControllerTest {
     }
 
     @Test
-    @DisplayName("로그아웃 성공: 헤더 검증 후 서비스 로그아웃과 쿠키 삭제 메서드를 호출합니다.")
+    @DisplayName("로그아웃 성공: 헤더 없이 요청해도 서비스의 logout(request, response)이 호출되어야 함")
     void logout_Success() throws Exception {
-        // given
-        String accessToken = "valid-access-token";
-        String authHeader = "Bearer " + accessToken;
-
-        doNothing().when(loginService).logout(accessToken);
-        doNothing().when(cookieUtil).deleteRefreshCookie(any(HttpServletResponse.class));
-
         // when & then
-        mockMvc.perform(post("/api/auth/logout")
-                        .header("Authorization", authHeader))
+        mockMvc.perform(post("/api/auth/logout")) // 💡 Header 제거됨
                 .andExpect(status().isNoContent());
 
-        // Verify
-        verify(loginService).logout(accessToken); // "Bearer " 떼고 넘겼는지 확인
-        verify(cookieUtil).deleteRefreshCookie(any(HttpServletResponse.class));
+        // then
+        // 서비스가 request와 response를 받아서 내부에서 처리하는지 확인
+        verify(loginService).logout(any(HttpServletRequest.class), any(HttpServletResponse.class));
     }
 }

--- a/src/test/java/com/graduationCapstone/Probe/global/security/login/controller/LoginControllerTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/global/security/login/controller/LoginControllerTest.java
@@ -64,9 +64,7 @@ class LoginControllerTest {
 
         // when & then
         mockMvc.perform(post("/api/auth/reissue"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.accessToken").value(newAccessToken)) // Body에는 AT만 있어야 함
-                .andExpect(jsonPath("$.refreshToken").isEmpty()); // Controller에서 RT는 null로 내려줌
+                .andExpect(status().isNoContent());
 
         verify(loginService).reissue(eq(refreshToken), any(HttpServletResponse.class));
     }

--- a/src/test/java/com/graduationCapstone/Probe/global/security/login/service/LoginServiceTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/global/security/login/service/LoginServiceTest.java
@@ -1,5 +1,7 @@
 package com.graduationCapstone.Probe.global.security.login.service;
 
+import com.graduationCapstone.Probe.global.security.util.CookieUtil;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import com.graduationCapstone.Probe.global.exception.ErrorCode;
@@ -14,11 +16,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -35,8 +41,18 @@ class LoginServiceTest {
     @Mock
     private JwtUtil jwtUtil;
 
+    @Mock
+    private CookieUtil cookieUtil;
+
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        response = new MockHttpServletResponse();
+    }
+
     @Test
-    @DisplayName("토큰 재발급 성공: 유효한 RT가 들어오면 새로운 AT, RT를 발급하고 DB를 업데이트합니다.")
+    @DisplayName("토큰 재발급 성공: 새 토큰을 쿠키에 추가하는 메서드가 호출되어야 합니다.")
     void reissue_Success() {
         // given
         String oldRefreshToken = "old-refresh-token";
@@ -59,19 +75,17 @@ class LoginServiceTest {
         given(jwtUtil.createRefreshToken(userId)).willReturn(newRefreshToken);
 
         // when
-        TokenResponseDto result = loginService.reissue(oldRefreshToken);
+        TokenResponseDto result = loginService.reissue(oldRefreshToken, response);
 
         // then
-        // 반환된 DTO 값이 새 토큰인지 확인
         assertThat(result.accessToken()).isEqualTo(newAccessToken);
-        assertThat(result.refreshToken()).isEqualTo(newRefreshToken);
-
-        // DB에서 가져온 Entity의 updateToken 메서드가 호출되어 값이 바뀌었는지 확인
-        assertThat(storedToken.getRefreshToken()).isEqualTo(newRefreshToken);
+        // CookieUtil이 제대로 호출되었는지 검증
+        verify(cookieUtil).addAccessCookie(response, newAccessToken);
+        verify(cookieUtil).addRefreshCookie(response, newRefreshToken);
     }
 
     @Test
-    @DisplayName("재발급 실패: Refresh Token이 유효하지 않으면 예외가 발생합니다.")
+    @DisplayName("재발급 실패: 유효하지 않은 토큰이면 쿠키 삭제 메서드가 호출되어야 합니다.")
     void reissue_Fail_InvalidToken() {
         // given
         String invalidToken = "invalid-token";
@@ -80,9 +94,11 @@ class LoginServiceTest {
         given(jwtUtil.validateToken(invalidToken)).willReturn(false);
 
         // when & then
-        assertThatThrownBy(() -> loginService.reissue(invalidToken))
+        assertThatThrownBy(() -> loginService.reissue(invalidToken, response))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_REFRESH_TOKEN);
+
+        verify(cookieUtil).deleteRefreshCookie(response);
     }
 
     @Test
@@ -99,13 +115,13 @@ class LoginServiceTest {
         given(refreshTokenRepository.findById(userId)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> loginService.reissue(refreshToken))
+        assertThatThrownBy(() -> loginService.reissue(refreshToken, response))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.REFRESH_TOKEN_NOT_FOUND);
     }
 
     @Test
-    @DisplayName("재발급 실패: DB에 저장된 토큰과 요청한 토큰이 다르면 예외가 발생합니다.")
+    @DisplayName("재발급 실패: DB 토큰과 미일치 시 쿠키 삭제 메서드가 호출되어야 합니다.")
     void reissue_Fail_Mismatch() {
         // given
         String requestToken = "hacker-token";
@@ -122,24 +138,31 @@ class LoginServiceTest {
         given(refreshTokenRepository.findByUserId(userId)).willReturn(Optional.of(storedToken));
 
         // when & then
-        assertThatThrownBy(() -> loginService.reissue(requestToken))
+        assertThatThrownBy(() -> loginService.reissue(requestToken, response))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.REFRESH_TOKEN_MISMATCH);
+
+        verify(cookieUtil).deleteRefreshCookie(response);
     }
 
     @Test
-    @DisplayName("로그아웃 성공: 토큰에서 ID를 추출해 DB 삭제 메서드를 호출합니다.")
+    @DisplayName("로그아웃 성공: DB에서 삭제하고 모든 쿠키 삭제 메서드(deleteAll)를 호출해야 합니다.")
     void logout_Success() {
         // given
-        String accessToken = "valid-access-token";
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        String accessToken = "valid-access";
         Long userId = 1L;
 
+        // CookieUtil에서 AccessToken을 꺼내오는 상황 Mocking
+        given(cookieUtil.getCookieValue(any(), eq(CookieUtil.ACCESS_TOKEN_COOKIE_NAME))).willReturn(accessToken);
+        given(jwtUtil.validateToken(accessToken)).willReturn(true);
         given(jwtUtil.getUserId(accessToken)).willReturn(userId);
 
         // when
-        loginService.logout(accessToken);
+        loginService.logout(request, response);
 
         // then
         verify(refreshTokenRepository).deleteByUserId(userId);
+        verify(cookieUtil).deleteAllCookies(response);
     }
 }

--- a/src/test/java/com/graduationCapstone/Probe/global/security/login/service/LoginServiceTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/global/security/login/service/LoginServiceTest.java
@@ -79,6 +79,7 @@ class LoginServiceTest {
 
         // then
         assertThat(result.accessToken()).isEqualTo(newAccessToken);
+        assertThat(storedToken.getRefreshToken()).isEqualTo(newRefreshToken);
         // CookieUtil이 제대로 호출되었는지 검증
         verify(cookieUtil).addAccessCookie(response, newAccessToken);
         verify(cookieUtil).addRefreshCookie(response, newRefreshToken);
@@ -112,12 +113,14 @@ class LoginServiceTest {
         given(jwtUtil.getUserId(refreshToken)).willReturn(userId);
 
         // DB 조회 결과가 Empty
-        given(refreshTokenRepository.findById(userId)).willReturn(Optional.empty());
+        given(refreshTokenRepository.findByUserId(userId)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> loginService.reissue(refreshToken, response))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+
+        verify(cookieUtil).deleteRefreshCookie(response);
     }
 
     @Test


### PR DESCRIPTION
## 📝 PR 설명
기존의 헤더(Authorization)와 쿠키가 혼용되던 인증 방식을 완전한 쿠키 기반 인증으로 전환하고, 로그아웃 및 회원 탈퇴 시 브라우저에 남는 잔여 쿠키 문제를 해결하기 위해 CookieUtil 및 관련 로직을 리팩토링하였습니다.

## 🛠 주요 변경 사항
- deleteAllCookies() 메서드를 추가하여 access_token, refresh_token, JSESSIONID를 한 번에 소거할 수 있도록 했습니다.
- 로그아웃 시 요구하던 @RequestHeader("Authorization")을 제거했습니다. 이제 브라우저가 자동으로 보내는 쿠키를 서버가 직접 회수합니다.
- LoginService가 재발급(Reissue) 성공/실패 시의 쿠키 상태를 직접 관리하게 하여 컨트롤러의 코드를 간소화했습니다.
- UserController.delete() 호출 시 DB 삭제와 동시에 브라우저의 모든 인증 쿠키를 삭제하도록 deleteAllCookies를 연동했습니다.
- MockHttpServletResponse를 사용하여 서비스 레이어에서 실제로 쿠키 생성/삭제 메서드가 호출되었는지 verify를 통해 검증합니다. 

## 🧪 테스트 체크리스트
- [x] 회원 탈퇴 시 모든 인증 관련 쿠키 소거 확인
- [x] 유효하지 않은 Refresh Token으로 재발급 시도 시 쿠키 즉시 삭제 확인
- [x] 기존 JUnit 서비스/컨트롤러 테스트 통과

## 📸 스크린샷 또는 비디오


## ➕ 추가 사항


## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다
- [ ] 불필요한 코드를 제거했습니다
- [ ] 주석 처리를 필요한 만큼 하였습니다.
- [ ] PR 제목 또는 설명에 Jira 이슈 키를 포함했습니다

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
