### PR TITLE
[CST-97] fix: 프로젝트 생성 시 프로젝트 이름 중복 체크 및 사용자 검색 시 대소문자 구분 없이 검색 가능하도록 수정, 테스트 코드 보완

### DIFF
--- a/src/main/java/com/graduationCapstone/Probe/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/repository/ProjectRepository.java
@@ -1,6 +1,7 @@
 package com.graduationCapstone.Probe.domain.project.repository;
 
 import com.graduationCapstone.Probe.domain.project.entity.Project;
+import com.graduationCapstone.Probe.domain.project.entity.ProjectRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -26,4 +27,6 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
             "LEFT JOIN FETCH m.user " +
             "WHERE p.id = :id")
     Optional<Project> findByIdWithMembers(@Param("id") Long id);
+
+    boolean existsByProjectNameAndMembers_User_IdAndMembers_Role(String projectName, Long userId, ProjectRole role);
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/service/ProjectService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/service/ProjectService.java
@@ -65,6 +65,11 @@ public class ProjectService {
     public Mono<ProjectResponseDto> createProject(User user, ProjectCreateRequestDto request) {
         log.info("프로젝트 생성 시작: creator={}, projectName={}", user.getUsername(), request.projectName());
         return Mono.fromCallable(() -> {
+            if (projectRepository.existsByProjectNameAndMembers_User_IdAndMembers_Role(
+                    request.projectName(), user.getId(), ProjectRole.OWNER)) {
+                throw new CustomException(ErrorCode.DUPLICATE_PROJECT_NAME);
+            }
+
             User persistentUser = userRepository.findById(user.getId())
                     .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
@@ -188,7 +193,7 @@ public class ProjectService {
     public Flux<UserSearchResponseDto> searchUsers(String keyword, User currentUser) {
         log.info("사용자 검색 시작: keyword={}, requester={}", keyword, currentUser.getUsername());
         return Mono.fromCallable(() -> {
-                    List<User> users = userRepository.findByUsernameContainingOrEmailContaining(keyword, keyword)
+                    List<User> users = userRepository.findByUsernameContainingIgnoreCaseOrEmailContainingIgnoreCase(keyword, keyword)
                             .stream()
                             .filter(user -> !user.getId().equals(currentUser.getId()))
                             .toList();

--- a/src/main/java/com/graduationCapstone/Probe/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/user/repository/UserRepository.java
@@ -12,5 +12,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByGithubId(String githubId);
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
-    List<User> findByUsernameContainingOrEmailContaining(String username, String email);
+    List<User> findByUsernameContainingIgnoreCaseOrEmailContainingIgnoreCase(String username, String email);
 }

--- a/src/main/java/com/graduationCapstone/Probe/global/exception/ErrorCode.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/exception/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
 
     // 409 CONFLICT (데이터 충돌)
     DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "RESOURCE40901", "데이터 무결성 제약 조건(예: 중복 값)을 위반했습니다."),
+    DUPLICATE_PROJECT_NAME(HttpStatus.CONFLICT, "PROJ40901", "이미 동일한 이름의 프로젝트를 보유하고 있습니다."),
 
     // 500 INTERNAL SERVER ERROR (서버 내부 오류)
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER50001", "서버 내부 오류가 발생했습니다."),

--- a/src/test/java/com/graduationCapstone/Probe/domain/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/domain/project/service/ProjectServiceTest.java
@@ -111,11 +111,18 @@ class ProjectServiceTest {
             String requestName = "New Project";
             ProjectCreateRequestDto request = new ProjectCreateRequestDto(requestName, List.of());
 
+            given(projectRepository.existsByProjectNameAndMembers_User_IdAndMembers_Role(
+                    eq(requestName), eq(testUser.getId()), eq(ProjectRole.OWNER)))
+                    .willReturn(false);
+
             given(userRepository.findById(anyLong())).willReturn(Optional.of(testUser));
             given(projectRepository.save(any(Project.class))).willReturn(testProject);
             StepVerifier.create(projectService.createProject(testUser, request))
                     .assertNext(res -> assertThat(res).isNotNull())
                     .verifyComplete();
+
+            verify(projectRepository).existsByProjectNameAndMembers_User_IdAndMembers_Role(
+                    eq(requestName), eq(testUser.getId()), eq(ProjectRole.OWNER));
 
             ArgumentCaptor<Project> projectCaptor = ArgumentCaptor.forClass(Project.class);
             verify(projectRepository, times(1)).save(projectCaptor.capture());
@@ -157,11 +164,15 @@ class ProjectServiceTest {
         @Test
         @DisplayName("프로젝트 삭제 실패(OWNER가 아닌 경우)")
         void delete_Fail_NotOwner() {
+            Long projectId = 10L;
+            Long userId = 2L;
+
+            given(projectRepository.existsById(projectId)).willReturn(true);
             // OWNER가 아니라고 가정
-            given(projectMemberRepository.existsByProjectIdAndUserIdAndRole(10L, 2L, ProjectRole.OWNER))
+            given(projectMemberRepository.existsByProjectIdAndUserIdAndRole(projectId, userId, ProjectRole.OWNER))
                     .willReturn(false);
 
-            StepVerifier.create(projectService.deleteProject(10L, 2L))
+            StepVerifier.create(projectService.deleteProject(projectId, userId))
                     .expectErrorMatches(e -> e instanceof CustomException &&
                             ((CustomException) e).getErrorCode() == ErrorCode.NOT_PROJECT_OWNER)
                     .verify();
@@ -242,13 +253,19 @@ class ProjectServiceTest {
         @Test
         @DisplayName("사용자 검색 (나 자신은 제외)")
         void searchUsers_Success() {
+            String keyword = "pRoBe";
             User other = User.builder().id(2L).username("other").email("o@o.com").build();
-            given(userRepository.findByUsernameContainingOrEmailContaining(anyString(), anyString()))
+            given(userRepository.findByUsernameContainingIgnoreCaseOrEmailContainingIgnoreCase(eq(keyword), eq(keyword)))
                     .willReturn(List.of(testUser, other));
 
             StepVerifier.create(projectService.searchUsers("keyword", testUser))
-                    .assertNext(res -> assertThat(res.username()).isEqualTo("other"))
+                    .assertNext(res -> {
+                        assertThat(res.username()).isEqualTo("other_user");
+                        assertThat(res.userId()).isNotEqualTo(testUser.getId());
+                    })
                     .verifyComplete();
+
+            verify(userRepository).findByUsernameContainingIgnoreCaseOrEmailContainingIgnoreCase(eq(keyword), eq(keyword));
         }
 
         @Test


### PR DESCRIPTION
## 📝 PR 설명
프로젝트 생성 시 프로젝트 이름 중복 체크 및 사용자 검색 시 대소문자 구분 없이 검색 가능하도록 수정, 테스트 코드 보완

## 🛠 주요 변경 사항
- 프로젝트 이름 중복 체크: 프로젝트 생성 시, 해당 사용자가 이미 보유한 프로젝트 이름과 중복되는지 확인하는 로직을 추가했습니다. (DUPLICATE_PROJECT_NAME 에러 처리)
- 대소문자 무시 검색: 사용자 검색 시 IgnoreCase를 적용하여 검색 편의성을 높였습니다.

## 🧪 테스트 체크리스트
- [ ] 프로젝트 생성 시 프로젝트 이름 중복 체크
- [ ] 대소문자 구분 없이 사용자 검색

## 📸 스크린샷 또는 비디오

## ➕ 추가 사항

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다
- [ ] 불필요한 코드를 제거했습니다
- [ ] 주석 처리를 필요한 만큼 하였습니다.
- [ ] PR 제목 또는 설명에 Jira 이슈 키를 포함했습니다

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
