### PR TITLE
[Cst-97] fix: 사용자 검색 로직 변경 및 사용자 레포지토리 정보 추가

### DIFF
--- a/src/main/java/com/graduationCapstone/Probe/domain/github/dto/GithubRepoResponseDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/github/dto/GithubRepoResponseDto.java
@@ -3,6 +3,8 @@ package com.graduationCapstone.Probe.domain.github.dto;
 import com.graduationCapstone.Probe.domain.github.entity.GithubRepo;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDateTime;
+
 @Schema(description = "GitHub 레포지토리 정보 응답 DTO")
 public record GithubRepoResponseDto(
         @Schema(description = "레포지토리 고유 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
@@ -27,7 +29,13 @@ public record GithubRepoResponseDto(
         int stargazersCount,
 
         @Schema(description = "오픈된 이슈 수")
-        int openIssuesCount
+        int openIssuesCount,
+
+        @Schema(description = "public, private 여부")
+        boolean isPublic,
+
+        @Schema(description = "업데이트 날짜")
+        LocalDateTime updatedAt
 ) {
     public static GithubRepoResponseDto from(GithubRepo repo) {
         return new GithubRepoResponseDto(
@@ -38,7 +46,9 @@ public record GithubRepoResponseDto(
                 repo.getLanguage(),
                 repo.getForksCount(),
                 repo.getStargazersCount(),
-                repo.getOpenIssuesCount()
+                repo.getOpenIssuesCount(),
+                repo.isPublic(),
+                repo.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/github/dto/GithubRepoSummaryDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/github/dto/GithubRepoSummaryDto.java
@@ -2,6 +2,8 @@ package com.graduationCapstone.Probe.domain.github.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDateTime;
+
 public record GithubRepoSummaryDto(
         @Schema(description = "레포지토리 이름", example = "Probe-Project", requiredMode = Schema.RequiredMode.REQUIRED)
         String repoName,
@@ -22,6 +24,12 @@ public record GithubRepoSummaryDto(
         int stargazersCount,
 
         @Schema(description = "오픈된 이슈 수")
-        int openIssuesCount
+        int openIssuesCount,
+
+        @Schema(description = "public, private 여부")
+        boolean isPublic,
+
+        @Schema(description = "업데이트 날짜")
+        LocalDateTime updatedAt
 ) {
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/github/entity/GithubRepo.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/github/entity/GithubRepo.java
@@ -5,6 +5,8 @@ import com.graduationCapstone.Probe.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -39,6 +41,12 @@ public class GithubRepo {
     @Column(name = "repo_open_issues_count")
     private int openIssuesCount;
 
+    @Column(name = "repo_is_public", nullable = false)
+    private boolean isPublic;
+
+    @Column(name = "repo_updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
@@ -50,5 +58,7 @@ public class GithubRepo {
         this.forksCount = dto.forksCount();
         this.stargazersCount = dto.stargazersCount();
         this.openIssuesCount = dto.openIssuesCount();
+        this.isPublic = dto.isPublic();
+        this.updatedAt = dto.updatedAt();
     }
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/github/service/GithubRepoService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/github/service/GithubRepoService.java
@@ -80,7 +80,7 @@ public class GithubRepoService {
     private GithubRepoResponseDto mapToResponse(GithubRepo repo) {
         return new GithubRepoResponseDto(
                 repo.getId(), repo.getRepoName(), repo.getOwner(), repo.getDescription(),
-                repo.getLanguage(), repo.getForksCount(), repo.getStargazersCount(), repo.getOpenIssuesCount()
+                repo.getLanguage(), repo.getForksCount(), repo.getStargazersCount(), repo.getOpenIssuesCount(), repo.isPublic(), repo.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/github/service/GithubService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/github/service/GithubService.java
@@ -15,6 +15,8 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -50,15 +52,27 @@ public class GithubService {
                             log.error("GitHub API 인증 실패: 401 Unauthorized");
                             return Mono.error(new CustomException(ErrorCode.UNAUTHORIZED_ACCESS));})
                 .bodyToFlux(new ParameterizedTypeReference<Map<String, Object>>() {})
-                .map(repo -> new GithubRepoSummaryDto(
-                        (String) repo.get("name"),
-                        (String) ((Map<?, ?>) repo.get("owner")).get("login"),
-                        (String) repo.get("description"),
-                        (String) repo.get("language"),
-                        repo.get("forks_count") != null ? (int) repo.get("forks_count") : 0,
-                        repo.get("stargazers_count") != null ? (int) repo.get("stargazers_count") : 0,
-                        repo.get("open_issues_count") != null ? (int) repo.get("open_issues_count") : 0
-                ))
+                .map(repo -> {
+                    String updatedAtStr = (String) repo.get("updated_at");
+                    LocalDateTime updatedAt = (updatedAtStr != null)
+                            ? ZonedDateTime.parse(updatedAtStr).toLocalDateTime()
+                            : LocalDateTime.now();
+
+                    // GitHub API는 private이면 true를 반환하므로 반전(!) 처리
+                    boolean isPublic = repo.get("private") != null && !(boolean) repo.get("private");
+
+                    return new GithubRepoSummaryDto(
+                            (String) repo.get("name"),
+                            (String) ((Map<?, ?>) repo.get("owner")).get("login"),
+                            (String) repo.get("description"),
+                            (String) repo.get("language"),
+                            repo.get("forks_count") != null ? (int) repo.get("forks_count") : 0,
+                            repo.get("stargazers_count") != null ? (int) repo.get("stargazers_count") : 0,
+                            repo.get("open_issues_count") != null ? (int) repo.get("open_issues_count") : 0,
+                            isPublic,
+                            updatedAt
+                    );
+                })
                 .collectList()
                 .doOnSuccess(list -> log.info("GitHub 레포지토리 목록 조회 완료: count={}", list.size()))
                 .onErrorMap(e -> {

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/service/ProjectService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/service/ProjectService.java
@@ -221,7 +221,7 @@ public class ProjectService {
     public Flux<UserSearchResponseDto> searchUsers(String keyword, User currentUser) {
         log.info("사용자 검색 시작: keyword={}, requester={}", keyword, currentUser.getUsername());
         return Mono.fromCallable(() -> {
-                    List<User> users = userRepository.findByUsernameContainingIgnoreCaseOrEmailContainingIgnoreCase(keyword, keyword)
+                    List<User> users = userRepository.findByUsernameContainingIgnoreCase(keyword)
                             .stream()
                             .filter(user -> !user.getId().equals(currentUser.getId()))
                             .toList();

--- a/src/main/java/com/graduationCapstone/Probe/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/user/repository/UserRepository.java
@@ -12,5 +12,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByGithubId(String githubId);
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
-    List<User> findByUsernameContainingIgnoreCaseOrEmailContainingIgnoreCase(String username, String email);
+    List<User> findByUsernameContainingIgnoreCase(String username);
 }

--- a/src/test/java/com/graduationCapstone/Probe/domain/github/service/GithubRepoServiceTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/domain/github/service/GithubRepoServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.test.StepVerifier;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -33,7 +34,7 @@ class GithubRepoServiceTest {
     void insertRepoTest() {
         // given
         User user = User.builder().id(1L).build();
-        GithubRepoSummaryDto dto = new GithubRepoSummaryDto("NewRepo", "owner", "description", "Java", 0, 0, 0);
+        GithubRepoSummaryDto dto = new GithubRepoSummaryDto("NewRepo", "owner", "description", "Java", 0, 0, 0, true, LocalDateTime.now());
 
         when(githubRepoRepository.findByUserIdAndRepoName(1L, "NewRepo")).thenReturn(Optional.empty());
 
@@ -43,6 +44,8 @@ class GithubRepoServiceTest {
             return GithubRepo.builder()
                     .id(200L) // 신규 생성된 ID 가정
                     .repoName(savedRepo.getRepoName())
+                    .isPublic(savedRepo.isPublic())
+                    .updatedAt(savedRepo.getUpdatedAt())
                     .user(user)
                     .build();
         });
@@ -63,8 +66,14 @@ class GithubRepoServiceTest {
     @DisplayName("레포지토리 저장 시 이미 존재하면 정보를 업데이트합니다.")
     void upsertRepoTest() {
         User user = User.builder().id(1L).build();
-        GithubRepoSummaryDto dto = new GithubRepoSummaryDto("Probe", "owner", "desc", "Java", 1, 1, 1);
-        GithubRepo existing = GithubRepo.builder().id(100L).repoName("Probe").user(user).build();
+        GithubRepoSummaryDto dto = new GithubRepoSummaryDto("Probe", "owner", "desc", "Java", 1, 1, 1, true, LocalDateTime.now());
+        GithubRepo existing = GithubRepo.builder()
+                .id(100L)
+                .repoName("Probe")
+                .isPublic(true)
+                .updatedAt(LocalDateTime.now().minusDays(1))
+                .user(user)
+                .build();
 
         when(githubRepoRepository.findByUserIdAndRepoName(1L, "Probe")).thenReturn(Optional.of(existing));
         when(githubRepoRepository.save(any())).thenReturn(existing);

--- a/src/test/java/com/graduationCapstone/Probe/domain/github/service/GithubServiceTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/domain/github/service/GithubServiceTest.java
@@ -1,5 +1,6 @@
 package com.graduationCapstone.Probe.domain.github.service;
 
+import com.graduationCapstone.Probe.domain.github.dto.GithubRepoSummaryDto;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.*;
@@ -33,11 +34,21 @@ class GithubServiceTest {
     void getRepoListTest() {
         mockWebServer.enqueue(new MockResponse()
                 .setHeader("Content-Type", "application/json")
-                .setBody("[{\"name\":\"Probe\", \"owner\":{\"login\":\"user\"}}]"));
+                .setBody("[{" +
+                        "\"name\":\"Probe\", " +
+                        "\"owner\":{\"login\":\"user\"}, " +
+                        "\"private\": false, " +
+                        "\"updated_at\": \"2024-03-29T10:00:00Z\"" +
+                        "}]"));
 
         githubService.getRepoList("token")
                 .as(StepVerifier::create)
-                .expectNextMatches(list -> list.getFirst().repoName().equals("Probe"))
+                .expectNextMatches(list -> {
+                    GithubRepoSummaryDto dto = list.getFirst();
+                    return dto.repoName().equals("Probe") &&
+                            dto.isPublic() &&
+                            dto.updatedAt() != null;
+                })
                 .verifyComplete();
     }
 

--- a/src/test/java/com/graduationCapstone/Probe/domain/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/domain/project/service/ProjectServiceTest.java
@@ -6,6 +6,7 @@ import com.graduationCapstone.Probe.domain.github.repository.GithubRepoRepositor
 import com.graduationCapstone.Probe.domain.project.dto.*;
 import com.graduationCapstone.Probe.domain.project.entity.Project;
 import com.graduationCapstone.Probe.domain.project.entity.ProjectMember;
+import com.graduationCapstone.Probe.domain.project.entity.ProjectRepo;
 import com.graduationCapstone.Probe.domain.project.entity.ProjectRole;
 import com.graduationCapstone.Probe.domain.project.repository.ProjectMemberRepository;
 import com.graduationCapstone.Probe.domain.project.repository.ProjectRepoRepository;
@@ -34,6 +35,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -102,6 +105,9 @@ class ProjectServiceTest {
 
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.delete(anyString())).willReturn(Mono.just(true));
+
+        given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class)))
+                .willReturn(Mono.just(true));
 
         given(transactionTemplate.execute(any())).willAnswer(invocation -> {
             TransactionCallback<?> callback = invocation.getArgument(0);
@@ -235,6 +241,8 @@ class ProjectServiceTest {
 
             StepVerifier.create(projectService.acceptInvitationByToken("token")).verifyComplete();
 
+            verify(valueOperations).setIfAbsent(contains("lock:project:join:"), anyString(), any(Duration.class));
+
             // 추가된 멤버의 권한이 MEMBER인지 검증
             ArgumentCaptor<Project> projectCaptor = ArgumentCaptor.forClass(Project.class);
             verify(projectRepository).save(projectCaptor.capture());
@@ -286,7 +294,7 @@ class ProjectServiceTest {
         void searchUsers_Success() {
             String keyword = "pRoBe";
             User other = User.builder().id(2L).username("other").email("o@o.com").build();
-            given(userRepository.findByUsernameContainingIgnoreCaseOrEmailContainingIgnoreCase(eq(keyword), eq(keyword)))
+            given(userRepository.findByUsernameContainingIgnoreCase(eq(keyword)))
                     .willReturn(List.of(testUser, other));
 
             StepVerifier.create(projectService.searchUsers(keyword, testUser))
@@ -296,7 +304,7 @@ class ProjectServiceTest {
                     })
                     .verifyComplete();
 
-            verify(userRepository).findByUsernameContainingIgnoreCaseOrEmailContainingIgnoreCase(eq(keyword), eq(keyword));
+            verify(userRepository).findByUsernameContainingIgnoreCase(eq(keyword));
         }
 
         @Test
@@ -342,9 +350,22 @@ class ProjectServiceTest {
         @Test
         @DisplayName("프로젝트 레포지토리 목록 조회")
         void getRepoList_Success() {
+            GithubRepo repo = GithubRepo.builder()
+                    .id(50L)
+                    .repoName("My Repo")
+                    .isPublic(true)
+                    .updatedAt(LocalDateTime.now())
+                    .build();
+            ProjectRepo pr = ProjectRepo.builder().githubRepo(repo).project(testProject).build();
+            testProject.addProjectRepo(pr);
+
             given(projectRepository.findByIdWithRepos(10L)).willReturn(Optional.of(testProject));
             StepVerifier.create(projectService.getProjectRepoList(10L))
-                    .assertNext(list -> assertThat(list).isNotNull())
+                    .assertNext(list -> {
+                        assertThat(list.get(0).repoName()).isEqualTo("My Repo");
+                        assertThat(list.get(0).isPublic()).isTrue();
+                        assertThat(list.get(0).updatedAt()).isNotNull();
+                    })
                     .verifyComplete();
 
             verify(transactionTemplate).execute(any());


### PR DESCRIPTION
## 📝 PR 설명
검색 로직 변경 및 사용자 레포지토리 정보 추가

## 🛠 주요 변경 사항
- 사용자 검색 로직 변경: 사용자 검색 시 이메일 검색을 제외하고 닉네임 기반 검색으로 일원화했습니다.
- 사용자 레포지토리 정보 추가: GithubRepo 엔티티와 DTO에 공개 여부(isPublic) 및 최근 업데이트 시간(updatedAt) 필드를 추가하고 GitHub API 연동 로직을 최신화했습니다.
- 로직 변경에 따른 테스트 코드 최신화

## 🧪 테스트 체크리스트
- [ ] 사용자 검색 시 닉네임으로 검색
- [ ] 레포지토리 조회 시 공개 여부(isPublic)과 최근 업데이트 시간(updatedAt) 정보 확인

## 📸 스크린샷 또는 비디오

## ➕ 추가 사항

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다
- [ ] 불필요한 코드를 제거했습니다
- [ ] 주석 처리를 필요한 만큼 하였습니다.
- [ ] PR 제목 또는 설명에 Jira 이슈 키를 포함했습니다

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
