### PR TITLE
[CST-103] feat: 테스트 관리 대시보드 API 구현

### DIFF
--- a/src/main/java/com/graduationCapstone/Probe/domain/agent/controller/AgentController.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/agent/controller/AgentController.java
@@ -4,6 +4,7 @@ import com.graduationCapstone.Probe.domain.agent.dto.AgentPlanTriggerRequestDto;
 import com.graduationCapstone.Probe.domain.agent.dto.AgentTestTriggerRequestDto;
 import com.graduationCapstone.Probe.domain.agent.service.AgentDispatchService;
 import com.graduationCapstone.Probe.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -40,6 +41,7 @@ public class AgentController {
             @ApiResponse(responseCode = "400", description = "잘못된 요청 인자"),
             @ApiResponse(responseCode = "404", description = "프로젝트 또는 시나리오를 찾을 수 없음")
     })
+    @Hidden
     @PostMapping("/dispatch/plan")
     public ResponseEntity<Map<String, Long>> triggerPlanGeneration(
             @AuthenticationPrincipal User user,

--- a/src/main/java/com/graduationCapstone/Probe/domain/agent/service/AgentCallbackService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/agent/service/AgentCallbackService.java
@@ -95,7 +95,7 @@ public class AgentCallbackService {
         if (dto.results() != null && !dto.results().isEmpty()) {
             List<TestResult> results = dto.results().stream()
                     .map(r -> TestResult.builder()
-                            .executionId(dto.executionId())
+                            .testExecution(execution)
                             .testCaseNumber(r.testCaseNumber())
                             .caseName(r.caseName())
                             .testCodeName(r.testCodeName())

--- a/src/main/java/com/graduationCapstone/Probe/domain/agent/service/AgentDispatchService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/agent/service/AgentDispatchService.java
@@ -103,7 +103,7 @@ public class AgentDispatchService {
 
         log.info("TestExecution created. Id={}, ScenarioId={}", execution.getExecutionId(), execution.getTestScenarioId());
 
-        // 4. 레포지토리 URL 조회
+        // 4. 레포지토리 URL 조회 -> projectId 대신 전달받은 repoId로 정확한 레포지토리 정보 조회
         GithubRepository targetRepo = githubRepositoryRepository.findByProjectId(projectId)
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
 

--- a/src/main/java/com/graduationCapstone/Probe/domain/agent/service/AgentDispatchService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/agent/service/AgentDispatchService.java
@@ -103,7 +103,7 @@ public class AgentDispatchService {
 
         log.info("TestExecution created. Id={}, ScenarioId={}", execution.getExecutionId(), execution.getTestScenarioId());
 
-        // 4. 레포지토리 URL 조회 -> projectId 대신 전달받은 repoId로 정확한 레포지토리 정보 조회
+        // 4. 레포지토리 URL 조회
         GithubRepository targetRepo = githubRepositoryRepository.findByProjectId(projectId)
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
 

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/controller/TestController.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/controller/TestController.java
@@ -284,8 +284,8 @@ public class TestController {
 
         return switch (type) {
             case "visual" -> ResponseEntity.ok(new TestResultDetailVisualDto(r.getStatus().name(), r.getScreenshotS3Urls()));
-            case "code" -> ResponseEntity.ok(new TestResultDetailCodeDto(r.getTestExecution().getTesterName(), r.getStatus().name(), r.getCreatedAt(), r.getTestCode()));
-            case "basic" -> ResponseEntity.ok(new TestResultDetailBasicDto(r.getTestExecution().getTesterName(), r.getStatus().name(), r.getCreatedAt(), r.getErrorLog()));
+            case "code" -> ResponseEntity.ok(new TestResultDetailCodeDto(r.getTestExecution().getTesterName(), r.getStatus().name(), r.getTestExecution().getCompletedAt(), r.getTestCode()));
+            case "basic" -> ResponseEntity.ok(new TestResultDetailBasicDto(r.getTestExecution().getTesterName(), r.getStatus().name(), r.getTestExecution().getCompletedAt(), r.getErrorLog()));
             default -> ResponseEntity.badRequest().build();
         };
     }

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/controller/TestController.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/controller/TestController.java
@@ -1,0 +1,301 @@
+package com.graduationCapstone.Probe.domain.test.controller;
+
+import com.graduationCapstone.Probe.domain.test.dto.*;
+import com.graduationCapstone.Probe.domain.test.entity.*;
+import com.graduationCapstone.Probe.domain.test.repository.*;
+import com.graduationCapstone.Probe.domain.test.service.TestService;
+import com.graduationCapstone.Probe.domain.user.entity.User;
+import com.graduationCapstone.Probe.global.exception.ErrorCode;
+import com.graduationCapstone.Probe.global.exception.handler.CustomException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@Tag(name = "Test", description = "테스트 대시보드 및 결과 데이터 관리 API")
+@RestController
+@RequestMapping("/api/projects/{projectId}/tests")
+@RequiredArgsConstructor
+public class TestController {
+
+    private final TestService testService;
+    private final TestGroupRepository groupRepo;
+    private final TestExecutionRepository executionRepo;
+    private final TestResultRepository resultRepo;
+
+    // ── 초기 설정 및 중복 체크 ──
+
+    @Operation(summary = "테스트 그룹 엔티티 생성", description = "테스트 그룹 및 실행 데이터를 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터")
+    })
+    @PostMapping("/setup")
+    public ResponseEntity<Void> setup(
+            @PathVariable Long projectId,
+            @AuthenticationPrincipal User user,
+            @Valid @RequestBody TestGroupCreateRequestDto dto) {
+        testService.createTestEntities(user, projectId, dto);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "테스트 그룹명 중복 체크", description = "프로젝트 내에 동일한 테스트 그룹명이 존재하는지 확인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "중복 여부 반환 성공")})
+    @GetMapping("/check-duplicate")
+    public ResponseEntity<Boolean> checkDuplicate(
+            @PathVariable Long projectId,
+            @RequestParam String name) {
+        return ResponseEntity.ok(testService.isGroupNameDuplicate(projectId, name));
+    }
+
+    // ── 수정 및 삭제 (Management) ──
+
+    @Operation(summary = "테스트 그룹명 수정", description = "프로젝트 소유권 확인 후 테스트 그룹명을 업데이트합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 입력값"),
+            @ApiResponse(responseCode = "403", description = "해당 프로젝트에 속하지 않은 테스트 그룹"),
+            @ApiResponse(responseCode = "404", description = "테스트 그룹 정보를 찾을 수 없음")
+    })
+    @PatchMapping("/groups/{groupId}")
+    public ResponseEntity<Void> updateGroupName(
+            @PathVariable Long projectId,
+            @PathVariable Long groupId,
+            @Valid @RequestBody TestGroupNameUpdateDto dto) {
+        testService.updateGroupName(projectId, groupId, dto.newGroupName());
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "테스트 그룹 삭제", description = "특정 테스트 그룹을 삭제합니다.")
+    @ApiResponses(
+            {@ApiResponse(responseCode = "204", description = "삭제 성공"), @ApiResponse(responseCode = "404", description = "그룹 없음")})
+    @DeleteMapping("/groups/{groupId}")
+    public ResponseEntity<Void> deleteGroup(
+            @PathVariable Long projectId,
+            @PathVariable Long groupId) {
+        testService.deleteGroup(projectId, groupId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "테스트 코드명 수정", description = "개별 테스트 코드의 이름을 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "403", description = "프로젝트 소속 불일치"),
+            @ApiResponse(responseCode = "404", description = "결과 정보를 찾을 수 없음")
+    })
+    @PatchMapping("/results/{resultId}/name")
+    public ResponseEntity<Void> updateTestCodeName(
+            @PathVariable Long projectId,
+            @PathVariable Long resultId,
+            @Valid @RequestBody TestCodeNameUpdateDto dto) {
+        TestResult r = resultRepo.findById(resultId).orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        if (!r.getTestExecution().getProjectId().equals(projectId)) throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+
+        r.updateTestCodeName(dto.newTestCodeName());
+        resultRepo.save(r);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "테스트 코드 삭제 (Soft Delete)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "프로젝트 소속 불일치"),
+            @ApiResponse(responseCode = "404", description = "결과 정보를 찾을 수 없음")
+    })
+    @DeleteMapping("/results/{resultId}")
+    public ResponseEntity<Void> deleteResult(
+            @PathVariable Long projectId,
+            @PathVariable Long resultId) {
+        TestResult r = resultRepo.findById(resultId).orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        if (!r.getTestExecution().getProjectId().equals(projectId)) throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+
+        r.softDelete();
+        if (r.isDeleted()) resultRepo.save(r);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "테스트 실행 내역 삭제 (Soft Delete)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "프로젝트 소속 불일치"),
+            @ApiResponse(responseCode = "404", description = "실행 정보를 찾을 수 없음")
+    })
+    @DeleteMapping("/executions/{executionId}")
+    public ResponseEntity<Void> deleteExecution(
+            @PathVariable Long projectId,
+            @PathVariable Long executionId) {
+        TestExecution e = executionRepo.findById(executionId).orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        if (!e.getProjectId().equals(projectId)) throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+
+        e.softDelete();
+        if (e.isDeleted()) executionRepo.save(e);
+        return ResponseEntity.noContent().build();
+    }
+
+
+
+    // ── 목록 및 정렬 (Listings) ──
+
+    @Operation(summary = "테스트 그룹 조회", description = "특정 테스트 그룹의 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "그룹 정보를 찾을 수 없음")
+    })
+    @GetMapping("/groups/{groupId}")
+    public ResponseEntity<TestGroup> getGroup(
+            @PathVariable Long projectId,
+            @PathVariable Long groupId) {
+        TestGroup g = groupRepo.findById(groupId).orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        if (!g.getProjectId().equals(projectId)) throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        return ResponseEntity.ok(g);
+    }
+
+    @Operation(summary = "테스트 그룹 내(ID, 테스트코드명, 상태, 테스트 시간, 테스터, 일시) 조회 및 정렬 (필드 선택 가능)", description = "field를 입력하지 않으면 기본값(id)으로 정렬됩니다.")
+    @GetMapping("/list/basic") // 쿼리 파라미터 사용
+    public ResponseEntity<List<TestExecutionListDto>> getBasicListOptional(
+            @PathVariable Long projectId,
+            @RequestParam(required = false, defaultValue = "id") String field,
+            @RequestParam(defaultValue = "false") boolean asc) {
+        return ResponseEntity.ok(testService.getBasicSortedList(projectId, field, asc));
+    }
+
+    @Operation(summary = "프로젝트 내 테스트 그룹 정보(ID, 테스트명, Pass 비율, 테스트 시간, 테스터, 일시) 조회 및 정렬 (필드 선택 가능)",
+            description = "field 미입력 시 기본값(id)으로 정렬됩니다.")
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "요약 목록 조회 성공")})
+    @GetMapping("/list/summary") // 쿼리 파라미터 사용
+    public ResponseEntity<List<TestCaseSummaryDto>> getSummaryList(
+            @PathVariable Long projectId,
+            @RequestParam(required = false, defaultValue = "id") String field,
+            @RequestParam(defaultValue = "false") boolean asc) {
+        return ResponseEntity.ok(testService.getTestSummaryList(projectId, field, asc));
+    }
+
+    @Operation(summary = "테스트 그룹 내 레포지토리 검색", description = "특정 테스트 그룹의 targetRepoId 등 정보를 조회합니다.")
+    @GetMapping("/groups/{groupId}/repo")
+    public ResponseEntity<Long> getGroupRepo(@PathVariable Long projectId, @PathVariable Long groupId) {
+        TestGroup g = groupRepo.findById(groupId).orElseThrow();
+        if (!g.getProjectId().equals(projectId)) throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        return ResponseEntity.ok(g.getTargetRepoId());
+    }
+
+    // ── 상세 조회 및 다운로드 (Details & Downloads) ──
+
+    @Operation(summary = "테스트 계획서 다운로드", description = "S3에 저장된 테스트 계획서(.xlsx) URL로 리다이렉트합니다.")
+    @ApiResponses({@ApiResponse(responseCode = "302", description = "다운로드 URL로 이동")})
+    @GetMapping("/executions/{executionId}/download/plan")
+    public ResponseEntity<Void> downloadPlan(@PathVariable Long projectId, @PathVariable Long executionId) {
+        TestExecution e = executionRepo.findById(executionId).orElseThrow();
+        return ResponseEntity.status(302).location(URI.create(e.getPlanS3Url())).build();
+    }
+
+    @Operation(summary = "테스트 보고서 다운로드", description = "S3에 저장된 결과 보고서(.xlsx) URL로 리다이렉트합니다.")
+    @ApiResponses({@ApiResponse(responseCode = "302", description = "다운로드 URL로 이동")})
+    @GetMapping("/executions/{executionId}/download/report")
+    public ResponseEntity<Void> downloadReport(@PathVariable Long projectId, @PathVariable Long executionId) {
+        TestExecution e = executionRepo.findById(executionId).orElseThrow();
+        return ResponseEntity.status(302).location(URI.create(e.getPlanResultS3Url())).build();
+    }
+
+    @Operation(summary = "테스트 결과 중 테스트 시나리오 항목 조회", description = "대시보드에서 테스트 결과 상세 조회 시 '테스트 시나리오'을 눌렀을 때 떠야하는 항목들")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "상세 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "활성화된 결과가 없거나 찾을 수 없음")
+    })
+    @GetMapping("/results/{resultId}/view-full")
+    public ResponseEntity<TestResultDetailFullDto> getFullView(
+            @PathVariable Long projectId,
+            @PathVariable Long resultId) {
+        TestResult r = resultRepo.findActiveById(resultId).orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        if (!r.getTestExecution().getProjectId().equals(projectId)) throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+
+        ScenarioDetailData d = r.getScenarioDetail();
+        return ResponseEntity.ok(new TestResultDetailFullDto(
+                r.getTestExecution().getTesterName(), r.getStatus().name(), r.getCreatedAt(),
+                d.scenarioName(), d.description(), d.testCaseId(), d.testCaseName(),
+                d.precondition(), d.testData(), d.executionSteps(), d.result()
+        ));
+    }
+
+    @Operation(summary = "테스트 결과 중 결과, 테스트 코드, 증명 항목 조회", description = "대시보드에서 테스트 결과 상세 조회 시 type(basic -> 결과, code -> 테스트 코드, visual -> 증명)에 따라 다른 상세 정보를 반환합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "상세 정보 반환 성공"),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 type 파라미터"),
+            @ApiResponse(responseCode = "404", description = "결과 정보를 찾을 수 없음")
+    })
+    @GetMapping("/results/{resultId}/details")
+    public ResponseEntity<Object> getDetails(
+            @PathVariable Long projectId,
+            @PathVariable Long resultId,
+            @RequestParam String type) {
+        TestResult r = resultRepo.findById(resultId).orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        if (!r.getTestExecution().getProjectId().equals(projectId)) throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+
+        return switch (type) {
+            case "visual" -> ResponseEntity.ok(new TestResultDetailVisualDto(r.getStatus().name(), r.getScreenshotS3Urls()));
+            case "code" -> ResponseEntity.ok(new TestResultDetailCodeDto(r.getTestExecution().getTesterName(), r.getStatus().name(), r.getCreatedAt(), r.getTestCode()));
+            case "basic" -> ResponseEntity.ok(new TestResultDetailBasicDto(r.getTestExecution().getTesterName(), r.getStatus().name(), r.getCreatedAt(), r.getErrorLog()));
+            default -> ResponseEntity.badRequest().build();
+        };
+    }
+
+    // ── 통계 및 개수 (Stats & Counts) ──
+
+    @Operation(summary = "특정 프로젝트 내 테스트 케이스 총 개수", description = "특정 프로젝트 내에서 테스트 케이스의 총 개수를 조회합니다.")
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "개수 조회 성공")})
+    @GetMapping("/count/total")
+    public ResponseEntity<Long> getTotalCount(@PathVariable Long projectId) {
+        return ResponseEntity.ok(testService.countTotalExecutions(projectId));
+    }
+
+    @Operation(summary = "날짜별 평균 테스트 시간", description = "일자별 평균 소요 시간을 조회합니다.")
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "통계 조회 성공")})
+    @GetMapping("/stats/daily-avg")
+    public ResponseEntity<List<DailyAvgDurationResponseDto>> getDailyAvg(@PathVariable Long projectId) {
+        return ResponseEntity.ok(testService.getDailyAvgDurations(projectId));
+    }
+
+    @Operation(summary = "프로젝트 전체 통계 조회", description = "프로젝트 내 모든 테스트 그룹의 Pass/Block/Fail/Untest 개수 및 Pass 비율을 조회합니다.")
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "전체 통계 조회 성공")})
+    @GetMapping("/stats/project-global")
+    public ResponseEntity<PassRateResponseDto> getGlobalStats(@PathVariable Long projectId) {
+        return ResponseEntity.ok(testService.getProjectGlobalStats(projectId));
+    }
+
+    @Operation(summary = "테스트 케이스 통계 조회", description = "테스트 케이스 내의 Pass/Block/Fail/Untest 개수 및 Pass 비율을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "실행 통계 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "실행 정보를 찾을 수 없음")
+    })
+    @GetMapping("/{executionId}/stats")
+    public ResponseEntity<PassRateResponseDto> getStats(
+            @PathVariable Long projectId,
+            @PathVariable Long executionId) {
+        TestExecution exec = executionRepo.findById(executionId).orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        if (!exec.getProjectId().equals(projectId)) throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+
+        return ResponseEntity.ok(testService.getPassRateStats(executionId));
+    }
+
+    @Operation(summary = "특정 테스트 그룹 내 테스트 케이스 총 개수", description = "테스트 그룹 하위에 속한 모든 테스트 케이스 개수를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "개수 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "그룹 정보를 찾을 수 없음")
+    })
+    @GetMapping("/groups/{groupId}/count/results")
+    public ResponseEntity<Long> getCount(
+            @PathVariable Long projectId,
+            @PathVariable Long groupId) {
+        TestGroup group = groupRepo.findById(groupId).orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+        if (!group.getProjectId().equals(projectId)) throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        return ResponseEntity.ok(testService.countResultsInGroup(groupId));
+    }
+}

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/controller/TestController.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/controller/TestController.java
@@ -97,8 +97,12 @@ public class TestController {
             @PathVariable Long projectId,
             @PathVariable Long resultId,
             @Valid @RequestBody TestCodeNameUpdateDto dto) {
-        TestResult r = resultRepo.findById(resultId).orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
-        if (!r.getTestExecution().getProjectId().equals(projectId)) throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        TestResult r = resultRepo.findActiveById(resultId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        if (!r.getTestExecution().getProjectId().equals(projectId)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
 
         r.updateTestCodeName(dto.newTestCodeName());
         resultRepo.save(r);
@@ -115,8 +119,12 @@ public class TestController {
     public ResponseEntity<Void> deleteResult(
             @PathVariable Long projectId,
             @PathVariable Long resultId) {
-        TestResult r = resultRepo.findById(resultId).orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
-        if (!r.getTestExecution().getProjectId().equals(projectId)) throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        TestResult r = resultRepo.findActiveById(resultId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        if (!r.getTestExecution().getProjectId().equals(projectId)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
 
         r.softDelete();
         if (r.isDeleted()) resultRepo.save(r);
@@ -133,8 +141,12 @@ public class TestController {
     public ResponseEntity<Void> deleteExecution(
             @PathVariable Long projectId,
             @PathVariable Long executionId) {
-        TestExecution e = executionRepo.findById(executionId).orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
-        if (!e.getProjectId().equals(projectId)) throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        TestExecution e = executionRepo.findActiveById(executionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        if (!e.getProjectId().equals(projectId)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
 
         e.softDelete();
         if (e.isDeleted()) executionRepo.save(e);
@@ -151,12 +163,17 @@ public class TestController {
             @ApiResponse(responseCode = "404", description = "그룹 정보를 찾을 수 없음")
     })
     @GetMapping("/groups/{groupId}")
-    public ResponseEntity<TestGroup> getGroup(
+    public ResponseEntity<TestGroupResponseDto> getGroup(
             @PathVariable Long projectId,
             @PathVariable Long groupId) {
-        TestGroup g = groupRepo.findById(groupId).orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
-        if (!g.getProjectId().equals(projectId)) throw new CustomException(ErrorCode.INVALID_ARGUMENT);
-        return ResponseEntity.ok(g);
+        TestGroup g = groupRepo.findById(groupId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        if (!g.getProjectId().equals(projectId)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        return ResponseEntity.ok(TestGroupResponseDto.from(g));
     }
 
     @Operation(summary = "테스트 그룹 내(ID, 테스트코드명, 상태, 테스트 시간, 테스터, 일시) 조회 및 정렬 (필드 선택 가능)", description = "field를 입력하지 않으면 기본값(id)으로 정렬됩니다.")
@@ -182,8 +199,12 @@ public class TestController {
     @Operation(summary = "테스트 그룹 내 레포지토리 검색", description = "특정 테스트 그룹의 targetRepoId 등 정보를 조회합니다.")
     @GetMapping("/groups/{groupId}/repo")
     public ResponseEntity<Long> getGroupRepo(@PathVariable Long projectId, @PathVariable Long groupId) {
-        TestGroup g = groupRepo.findById(groupId).orElseThrow();
-        if (!g.getProjectId().equals(projectId)) throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        TestGroup g = groupRepo.findById(groupId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        if (!g.getProjectId().equals(projectId)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
         return ResponseEntity.ok(g.getTargetRepoId());
     }
 
@@ -193,7 +214,16 @@ public class TestController {
     @ApiResponses({@ApiResponse(responseCode = "302", description = "다운로드 URL로 이동")})
     @GetMapping("/executions/{executionId}/download/plan")
     public ResponseEntity<Void> downloadPlan(@PathVariable Long projectId, @PathVariable Long executionId) {
-        TestExecution e = executionRepo.findById(executionId).orElseThrow();
+        TestExecution e = executionRepo.findActiveById(executionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        if (!e.getProjectId().equals(projectId)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        if (e.getPlanS3Url() == null || e.getPlanS3Url().isBlank()) {
+            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
         return ResponseEntity.status(302).location(URI.create(e.getPlanS3Url())).build();
     }
 
@@ -201,7 +231,16 @@ public class TestController {
     @ApiResponses({@ApiResponse(responseCode = "302", description = "다운로드 URL로 이동")})
     @GetMapping("/executions/{executionId}/download/report")
     public ResponseEntity<Void> downloadReport(@PathVariable Long projectId, @PathVariable Long executionId) {
-        TestExecution e = executionRepo.findById(executionId).orElseThrow();
+        TestExecution e = executionRepo.findActiveById(executionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        if (!e.getProjectId().equals(projectId)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        if (e.getPlanResultS3Url() == null || e.getPlanResultS3Url().isBlank()) {
+            throw new CustomException(ErrorCode.RESOURCE_NOT_FOUND);
+        }
         return ResponseEntity.status(302).location(URI.create(e.getPlanResultS3Url())).build();
     }
 
@@ -219,7 +258,7 @@ public class TestController {
 
         ScenarioDetailData d = r.getScenarioDetail();
         return ResponseEntity.ok(new TestResultDetailFullDto(
-                r.getTestExecution().getTesterName(), r.getStatus().name(), r.getCreatedAt(),
+                r.getTestExecution().getTesterName(), r.getStatus().name(), r.getTestExecution().getCompletedAt(),
                 d.scenarioName(), d.description(), d.testCaseId(), d.testCaseName(),
                 d.precondition(), d.testData(), d.executionSteps(), d.result()
         ));
@@ -236,8 +275,12 @@ public class TestController {
             @PathVariable Long projectId,
             @PathVariable Long resultId,
             @RequestParam String type) {
-        TestResult r = resultRepo.findById(resultId).orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
-        if (!r.getTestExecution().getProjectId().equals(projectId)) throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        TestResult r = resultRepo.findActiveById(resultId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        if (!r.getTestExecution().getProjectId().equals(projectId)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
 
         return switch (type) {
             case "visual" -> ResponseEntity.ok(new TestResultDetailVisualDto(r.getStatus().name(), r.getScreenshotS3Urls()));

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/dto/DailyAvgDurationResponseDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/dto/DailyAvgDurationResponseDto.java
@@ -1,0 +1,4 @@
+package com.graduationCapstone.Probe.domain.test.dto;
+
+public record DailyAvgDurationResponseDto(String date, String averageDuration) {
+}

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/dto/PassRateResponseDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/dto/PassRateResponseDto.java
@@ -1,0 +1,4 @@
+package com.graduationCapstone.Probe.domain.test.dto;
+
+public record PassRateResponseDto(long passCount, long totalCount, String countString, String passRatio) {
+}

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestCaseSummaryDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestCaseSummaryDto.java
@@ -1,0 +1,8 @@
+package com.graduationCapstone.Probe.domain.test.dto;
+
+import java.time.LocalDateTime;
+
+public record TestCaseSummaryDto(
+        String testCaseId, String testGroupName,
+        String passRatio, String duration, String tester, LocalDateTime completedAt
+) {}

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestCodeNameUpdateDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestCodeNameUpdateDto.java
@@ -1,0 +1,8 @@
+package com.graduationCapstone.Probe.domain.test.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TestCodeNameUpdateDto(
+        @NotBlank(message = "수정할 테스트 코드명을 입력해주세요.")
+        String newTestCodeName
+) {}

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestExecutionListDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestExecutionListDto.java
@@ -1,0 +1,8 @@
+package com.graduationCapstone.Probe.domain.test.dto;
+
+import java.time.LocalDateTime;
+
+public record TestExecutionListDto(
+        String testCaseId, String testCodeName, String status,
+        String duration, String tester, LocalDateTime completedAt
+) {}

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestGroupCreateRequestDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestGroupCreateRequestDto.java
@@ -1,0 +1,20 @@
+package com.graduationCapstone.Probe.domain.test.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record TestGroupCreateRequestDto(
+        @NotBlank(message = "테스트 그룹명은 필수입니다.")
+        String baseTestGroupName,
+
+        @NotNull(message = "레포지토리 ID는 필수입니다.")
+        Long targetRepoId,
+
+        @NotEmpty(message = "최소 하나 이상의 시나리오를 선택해야 합니다.")
+        List<Long> scenarioIds,
+
+        @NotBlank(message = "대상 브랜치는 필수입니다.")
+        String targetBranch
+) {}

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestGroupNameUpdateDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestGroupNameUpdateDto.java
@@ -1,0 +1,8 @@
+package com.graduationCapstone.Probe.domain.test.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TestGroupNameUpdateDto(
+        @NotBlank(message = "수정할 그룹명을 입력해주세요.")
+        String newGroupName
+) {}

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestGroupResponseDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestGroupResponseDto.java
@@ -1,0 +1,38 @@
+package com.graduationCapstone.Probe.domain.test.dto;
+
+import com.graduationCapstone.Probe.domain.test.entity.TestGroup;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "테스트 그룹 상세 응답 DTO")
+@Builder
+public record TestGroupResponseDto(
+        @Schema(description = "테스트 그룹 ID")
+        Long groupId,
+
+        @Schema(description = "프로젝트 ID")
+        Long projectId,
+
+        @Schema(description = "테스트 그룹명")
+        String groupName,
+
+        @Schema(description = "타겟 레포지토리 ID")
+        Long targetRepoId,
+
+        @Schema(description = "타겟 브랜치명")
+        String targetBranch
+) {
+    /**
+     * TestGroup 엔티티를 DTO로 변환하는 정적 팩토리 메서드
+     * 연관 관계가 있는 컬렉션(testExecutions)을 제외하여 무한 재귀를 방지합니다.
+     */
+    public static TestGroupResponseDto from(TestGroup group) {
+        return TestGroupResponseDto.builder()
+                .groupId(group.getGroupId())
+                .projectId(group.getProjectId())
+                .groupName(group.getGroupName())
+                .targetRepoId(group.getTargetRepoId())
+                .targetBranch(group.getTargetBranch())
+                .build();
+    }
+}

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestResultDetailBasicDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestResultDetailBasicDto.java
@@ -1,0 +1,5 @@
+package com.graduationCapstone.Probe.domain.test.dto;
+
+import java.time.LocalDateTime;
+
+public record TestResultDetailBasicDto(String tester, String status, LocalDateTime completedAt, String errorLog) {}

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestResultDetailCodeDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestResultDetailCodeDto.java
@@ -1,0 +1,5 @@
+package com.graduationCapstone.Probe.domain.test.dto;
+
+import java.time.LocalDateTime;
+
+public record TestResultDetailCodeDto(String tester, String status, LocalDateTime completedAt, String testCode) {}

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestResultDetailFullDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestResultDetailFullDto.java
@@ -1,0 +1,9 @@
+package com.graduationCapstone.Probe.domain.test.dto;
+
+import java.time.LocalDateTime;
+
+public record TestResultDetailFullDto(
+        String tester, String status, LocalDateTime completedAt,
+        String scenarioName, String description, String testCodeId, String testCaseName,
+        String precondition, String testData, String executionSteps, String result
+) {}

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestResultDetailVisualDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestResultDetailVisualDto.java
@@ -1,0 +1,5 @@
+package com.graduationCapstone.Probe.domain.test.dto;
+
+import java.util.List;
+
+public record TestResultDetailVisualDto(String status, List<String> screenshotS3Urls) {}

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/entity/TestExecution.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/entity/TestExecution.java
@@ -4,6 +4,8 @@ import com.graduationCapstone.Probe.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,6 +16,8 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "test_execution")
+@SQLDelete(sql = "UPDATE test_execution SET deleted_at = NOW() WHERE execution_id = ?")
+@Where(clause = "deleted_at IS NULL")
 public class TestExecution {
 
     @Id

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/entity/TestExecution.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/entity/TestExecution.java
@@ -6,6 +6,7 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -19,6 +20,13 @@ public class TestExecution {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "execution_id")
     private Long executionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
+    private TestGroup testGroup; // 부모 연결
+
+    @OneToMany(mappedBy = "testExecution", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<TestResult> testResults;
 
     @Column(name = "project_id", nullable = false)
     private Long projectId;
@@ -135,5 +143,11 @@ public class TestExecution {
     /** 테스트명(코드명) 수정 */
     public void updateTestName(String testName) {
         this.testName = testName;
+    }
+
+    /** 테스트그룹명 수정 **/
+    public void updateGroupAndName(TestGroup group, String name) {
+        this.testGroup = group;
+        this.testName = name;
     }
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/entity/TestGroup.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/entity/TestGroup.java
@@ -1,0 +1,27 @@
+package com.graduationCapstone.Probe.domain.test.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "test_group")
+public class TestGroup {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long groupId;
+    private Long projectId;
+    private String groupName; // 입력한 테스트그룹명 (논리적 테이블 키)
+    private Long targetRepoId;
+    private String targetBranch;
+
+    @OneToMany(mappedBy = "testGroup", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TestExecution> testExecutions;
+
+    public void updateGroupName(String name) { this.groupName = name; }
+}

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/entity/TestGroup.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/entity/TestGroup.java
@@ -2,7 +2,10 @@ package com.graduationCapstone.Probe.domain.test.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
@@ -11,17 +14,50 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "test_group")
+@SQLDelete(sql = "UPDATE test_group SET deleted_at = NOW() WHERE group_id = ?") // delete() 호출 시 자동으로 deletedAt을 업데이트하다록 설정
+@Where(clause = "deleted_at IS NULL")
 public class TestGroup {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "group_id")
     private Long groupId;
+
+    @Column(name = "project_id", nullable = false)
     private Long projectId;
+
+    @Column(name = "group_name", nullable = false, length = 100)
     private String groupName; // 입력한 테스트그룹명 (논리적 테이블 키)
+
+    @Column(name = "target_repo_id")
     private Long targetRepoId;
+
+    @Column(name = "target_branch", length = 100)
     private String targetBranch;
 
     @OneToMany(mappedBy = "testGroup", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TestExecution> testExecutions;
 
-    public void updateGroupName(String name) { this.groupName = name; }
+    /** null이면 활성, 값이 있으면 삭제된 레코드 */
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    /** 테스트그룹명 수정 */
+    public void updateGroupName(String name) {
+        this.groupName = name;
+    }
+
+    /** Soft Delete 처리 */
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+
+        // 부모 삭제 시 자식들도 명시적으로 softDelete 호출
+        if (this.testExecutions != null) {
+            this.testExecutions.forEach(TestExecution::softDelete);
+        }
+    }
+
+    /** 삭제 여부 확인 */
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/entity/TestResult.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/entity/TestResult.java
@@ -22,8 +22,9 @@ public class TestResult {
     @Column(name = "result_id")
     private Long resultId;
 
-    @Column(name = "execution_id", nullable = false)
-    private Long executionId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "execution_id")
+    private TestExecution testExecution; //부모 연결
 
     // ── ID 구성 요소 ──
 
@@ -100,5 +101,10 @@ public class TestResult {
     /** 테스트 코드명 수정 */
     public void updateTestCodeName(String testCodeName) {
         this.testCodeName = testCodeName;
+    }
+
+    /** 테스트케이스ID 반환 */
+    public String getFullTestCaseId() {
+        return String.format("%s_%s", testExecution.getTestScenarioId(), this.testCaseNumber);
     }
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/entity/TestResult.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/entity/TestResult.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDateTime;
@@ -15,6 +17,8 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "test_result")
+@SQLDelete(sql = "UPDATE test_result SET deleted_at = NOW() WHERE result_id = ?")
+@Where(clause = "deleted_at IS NULL")
 public class TestResult {
 
     @Id
@@ -23,7 +27,7 @@ public class TestResult {
     private Long resultId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "execution_id")
+    @JoinColumn(name = "execution_id", nullable = false)
     private TestExecution testExecution; //부모 연결
 
     // ── ID 구성 요소 ──

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestExecutionRepository.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestExecutionRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface TestExecutionRepository extends JpaRepository<TestExecution, Long>, TestExecutionRepositoryCustom {
-    long countByProjectId(Long projectId);
+    long countByProjectIdAndDeletedAtIsNull(Long projectId);
     List<TestExecution> findAllByTestGroup_GroupId(Long testGroupGroupId);
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestExecutionRepository.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestExecutionRepository.java
@@ -3,6 +3,9 @@ package com.graduationCapstone.Probe.domain.test.repository;
 import com.graduationCapstone.Probe.domain.test.entity.TestExecution;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TestExecutionRepository extends JpaRepository<TestExecution, Long>, TestExecutionRepositoryCustom {
+import java.util.List;
 
+public interface TestExecutionRepository extends JpaRepository<TestExecution, Long>, TestExecutionRepositoryCustom {
+    long countByProjectId(Long projectId);
+    List<TestExecution> findAllByTestGroup_GroupId(Long testGroupGroupId);
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestExecutionRepositoryCustom.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestExecutionRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.graduationCapstone.Probe.domain.test.repository;
 
 import com.graduationCapstone.Probe.domain.test.entity.TestExecution;
+import com.querydsl.core.Tuple;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,4 +13,7 @@ public interface TestExecutionRepositoryCustom {
 
     /** Soft Delete 필터링된 단건 조회 */
     Optional<TestExecution> findActiveById(Long executionId);
+
+    /** 통계 정보 **/
+    List<Tuple> findDailyAvgDuration(Long projectId);
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestExecutionRepositoryCustom.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestExecutionRepositoryCustom.java
@@ -11,9 +11,15 @@ public interface TestExecutionRepositoryCustom {
     /** 프로젝트별 활성 시나리오 목록 (동적 정렬 지원) - 시나리오 대시보드용 */
     List<TestExecution> findAllActiveByProjectId(Long projectId, String sortField, boolean ascending);
 
+    List<TestExecution> findAllActiveWithResultsByProjectId(Long projectId, String sortField, boolean ascending);
+
     /** Soft Delete 필터링된 단건 조회 */
     Optional<TestExecution> findActiveById(Long executionId);
 
     /** 통계 정보 **/
     List<Tuple> findDailyAvgDuration(Long projectId);
+
+    /** 테스트그룹 정보까지 포함된 단건 조회 */
+    Optional<TestExecution> findActiveWithGroupById(Long executionId);
+
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestExecutionRepositoryImpl.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestExecutionRepositoryImpl.java
@@ -1,7 +1,9 @@
 package com.graduationCapstone.Probe.domain.test.repository;
 
+import com.graduationCapstone.Probe.domain.test.entity.ExecutionStatus;
 import com.graduationCapstone.Probe.domain.test.entity.QTestExecution;
 import com.graduationCapstone.Probe.domain.test.entity.TestExecution;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.ComparableExpressionBase;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -40,6 +42,15 @@ public class TestExecutionRepositoryImpl implements TestExecutionRepositoryCusto
                 )
                 .fetchOne();
         return Optional.ofNullable(result);
+    }
+
+    @Override
+    public List<Tuple> findDailyAvgDuration(Long projectId) {
+        return queryFactory.select(te.completedAt.stringValue().substring(0, 10), te.durationSeconds.avg())
+                .from(te)
+                .where(te.projectId.eq(projectId), te.status.eq(ExecutionStatus.COMPLETED))
+                .groupBy(te.completedAt.stringValue().substring(0, 10))
+                .fetch();
     }
 
     private OrderSpecifier<?> buildOrderSpecifier(String sortField, boolean ascending) {

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestExecutionRepositoryImpl.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestExecutionRepositoryImpl.java
@@ -68,7 +68,7 @@ public class TestExecutionRepositoryImpl implements TestExecutionRepositoryCusto
                 .selectFrom(te)
                 // 페이징 구현 시 defaoult_batch_fetch_size 설정 필요, 필요 시 수정 예정
                 .leftJoin(te.testResults, tr).fetchJoin() // 결과 미리 로딩
-                .leftJoin(te.testGroup, tg).fetchJoin()   // 그룹 정보 미리 로딩
+                .leftJoin(te.testGroup, tg).fetchJoin()   // 그룹 정보 미리 로딩 (NPE 방지)
                 .where(te.projectId.eq(projectId), te.deletedAt.isNull())
                 .orderBy(buildOrderSpecifier(sortField, ascending))
                 .fetch();

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestExecutionRepositoryImpl.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestExecutionRepositoryImpl.java
@@ -1,8 +1,6 @@
 package com.graduationCapstone.Probe.domain.test.repository;
 
-import com.graduationCapstone.Probe.domain.test.entity.ExecutionStatus;
-import com.graduationCapstone.Probe.domain.test.entity.QTestExecution;
-import com.graduationCapstone.Probe.domain.test.entity.TestExecution;
+import com.graduationCapstone.Probe.domain.test.entity.*;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.ComparableExpressionBase;
@@ -19,6 +17,8 @@ public class TestExecutionRepositoryImpl implements TestExecutionRepositoryCusto
 
     private final JPAQueryFactory queryFactory;
     private static final QTestExecution te = QTestExecution.testExecution;
+    private static final QTestResult tr = QTestResult.testResult;
+    private static final QTestGroup tg = QTestGroup.testGroup;
 
     @Override
     public List<TestExecution> findAllActiveByProjectId(Long projectId, String sortField, boolean ascending) {
@@ -46,11 +46,46 @@ public class TestExecutionRepositoryImpl implements TestExecutionRepositoryCusto
 
     @Override
     public List<Tuple> findDailyAvgDuration(Long projectId) {
-        return queryFactory.select(te.completedAt.stringValue().substring(0, 10), te.durationSeconds.avg())
+        return queryFactory
+                .select(
+                        te.completedAt.stringValue().substring(0, 10),
+                        te.durationSeconds.avg()
+                )
                 .from(te)
-                .where(te.projectId.eq(projectId), te.status.eq(ExecutionStatus.COMPLETED))
+                .where(
+                        te.projectId.eq(projectId),
+                        te.status.eq(ExecutionStatus.COMPLETED),
+                        te.deletedAt.isNull(),      // 삭제된 실행은 통계에서 제외
+                        te.completedAt.isNotNull()  // substring 연산을 위한 Null 방어
+                )
                 .groupBy(te.completedAt.stringValue().substring(0, 10))
                 .fetch();
+    }
+
+    @Override
+    public List<TestExecution> findAllActiveWithResultsByProjectId(Long projectId, String sortField, boolean ascending) {
+        return queryFactory
+                .selectFrom(te)
+                // 페이징 구현 시 defaoult_batch_fetch_size 설정 필요, 필요 시 수정 예정
+                .leftJoin(te.testResults, tr).fetchJoin() // 결과 미리 로딩
+                .leftJoin(te.testGroup, tg).fetchJoin()   // 그룹 정보 미리 로딩
+                .where(te.projectId.eq(projectId), te.deletedAt.isNull())
+                .orderBy(buildOrderSpecifier(sortField, ascending))
+                .fetch();
+    }
+
+    @Override
+    public Optional<TestExecution> findActiveWithGroupById(Long executionId) {
+        TestExecution result = queryFactory
+                .selectFrom(te)
+                .leftJoin(te.testGroup, tg).fetchJoin() // 연관된 그룹 정보를 즉시 로딩
+                .where(
+                        te.executionId.eq(executionId),
+                        te.deletedAt.isNull() // 삭제되지 않은 데이터만 조회
+                )
+                .fetchOne();
+
+        return Optional.ofNullable(result);
     }
 
     private OrderSpecifier<?> buildOrderSpecifier(String sortField, boolean ascending) {

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestGroupRepository.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestGroupRepository.java
@@ -1,0 +1,10 @@
+package com.graduationCapstone.Probe.domain.test.repository;
+
+import com.graduationCapstone.Probe.domain.test.entity.TestGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TestGroupRepository extends JpaRepository<TestGroup, Long> {
+    boolean existsByProjectIdAndGroupName(Long projectId, String groupName);
+}

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestResultRepository.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestResultRepository.java
@@ -6,6 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface TestResultRepository extends JpaRepository<TestResult, Long>, TestResultRepositoryCustom {
-
-    List<TestResult> findAllByExecutionId(Long executionId);
+    long countByTestExecution_TestGroup_GroupId(Long groupId);
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestResultRepository.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestResultRepository.java
@@ -4,5 +4,5 @@ import com.graduationCapstone.Probe.domain.test.entity.TestResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TestResultRepository extends JpaRepository<TestResult, Long>, TestResultRepositoryCustom {
-    long countByTestExecution_TestGroup_GroupId(Long groupId);
+    long countByTestExecution_TestGroup_GroupIdAndDeletedAtIsNull(Long groupId);
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestResultRepository.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestResultRepository.java
@@ -3,8 +3,6 @@ package com.graduationCapstone.Probe.domain.test.repository;
 import com.graduationCapstone.Probe.domain.test.entity.TestResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface TestResultRepository extends JpaRepository<TestResult, Long>, TestResultRepositoryCustom {
     long countByTestExecution_TestGroup_GroupId(Long groupId);
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestResultRepositoryCustom.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestResultRepositoryCustom.java
@@ -20,4 +20,7 @@ public interface TestResultRepositoryCustom {
 
     /** 특정 execution의 상태별 테스트 결과 개수 */
     Map<ResultStatus, Long> countByStatusForExecution(Long executionId);
+
+    /** 여러 Execution ID들에 대한 상태별 카운트를 한 번에 조회 */
+    Map<Long, Map<ResultStatus, Long>> findCountsByExecutionIds(List<Long> executionIds);
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestResultRepositoryImpl.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestResultRepositoryImpl.java
@@ -1,9 +1,6 @@
 package com.graduationCapstone.Probe.domain.test.repository;
 
-import com.graduationCapstone.Probe.domain.test.entity.QTestExecution;
-import com.graduationCapstone.Probe.domain.test.entity.QTestResult;
-import com.graduationCapstone.Probe.domain.test.entity.ResultStatus;
-import com.graduationCapstone.Probe.domain.test.entity.TestResult;
+import com.graduationCapstone.Probe.domain.test.entity.*;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.ComparableExpressionBase;
@@ -11,10 +8,8 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -23,13 +18,16 @@ public class TestResultRepositoryImpl implements TestResultRepositoryCustom {
     private final JPAQueryFactory queryFactory;
     private static final QTestResult tr = QTestResult.testResult;
     private static final QTestExecution te = QTestExecution.testExecution;
+    private static final QTestGroup tg = QTestGroup.testGroup;
 
     @Override
     public List<TestResult> findAllActiveByExecutionId(Long executionId, String sortField, boolean ascending) {
         return queryFactory
                 .selectFrom(tr)
+                .join(tr.testExecution, te).fetchJoin() // 부모 실행 정보도 함께 로드
                 .where(
                         tr.testExecution.executionId.eq(executionId),
+                        te.deletedAt.isNull(), // 부모가 삭제되었을 시 결과도 노출 X
                         tr.deletedAt.isNull()
                 )
                 .orderBy(buildOrderSpecifier(sortField, ascending))
@@ -42,7 +40,8 @@ public class TestResultRepositoryImpl implements TestResultRepositoryCustom {
                 .selectFrom(tr)
                 .where(
                         tr.resultId.eq(resultId),
-                        tr.deletedAt.isNull()
+                        tr.deletedAt.isNull(),
+                        te.deletedAt.isNull() // 부모가 삭제된 경우 조회 X
                 )
                 .fetchOne();
         return Optional.ofNullable(result);
@@ -72,12 +71,41 @@ public class TestResultRepositoryImpl implements TestResultRepositoryCustom {
                 .from(tr)
                 .where(
                         tr.testExecution.executionId.eq(executionId),
+                        te.deletedAt.isNull(),
                         tr.deletedAt.isNull()
                 )
                 .groupBy(tr.status)
                 .fetch();
 
         return toStatusMap(tuples);
+    }
+
+    @Override
+    public Map<Long, Map<ResultStatus, Long>> findCountsByExecutionIds(List<Long> executionIds) {
+        if (executionIds == null || executionIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        // executionId와 status별로 그룹화하여 카운트 조회
+        List<Tuple> results = queryFactory
+                .select(tr.testExecution.executionId, tr.status, tr.count())
+                .from(tr)
+                .where(
+                        tr.testExecution.executionId.in(executionIds),
+                        tr.deletedAt.isNull() // Soft Delete 필터링
+                )
+                .groupBy(tr.testExecution.executionId, tr.status)
+                .fetch();
+
+        // 결과를 Map<Long, Map<ResultStatus, Long>> 형태로 변환
+        // 예: {1L: {PASS: 10, FAIL: 2}, 2L: {PASS: 5, BLOCK: 1}}
+        return results.stream().collect(Collectors.groupingBy(
+                t -> t.get(tr.testExecution.executionId),
+                Collectors.toMap(
+                        t -> t.get(tr.status),
+                        t -> t.get(tr.count())
+                )
+        ));
     }
 
     private Map<ResultStatus, Long> toStatusMap(List<Tuple> tuples) {

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestResultRepositoryImpl.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestResultRepositoryImpl.java
@@ -18,7 +18,6 @@ public class TestResultRepositoryImpl implements TestResultRepositoryCustom {
     private final JPAQueryFactory queryFactory;
     private static final QTestResult tr = QTestResult.testResult;
     private static final QTestExecution te = QTestExecution.testExecution;
-    private static final QTestGroup tg = QTestGroup.testGroup;
 
     @Override
     public List<TestResult> findAllActiveByExecutionId(Long executionId, String sortField, boolean ascending) {
@@ -38,6 +37,7 @@ public class TestResultRepositoryImpl implements TestResultRepositoryCustom {
     public Optional<TestResult> findActiveById(Long resultId) {
         TestResult result = queryFactory
                 .selectFrom(tr)
+                .join(tr.testExecution, te)
                 .where(
                         tr.resultId.eq(resultId),
                         tr.deletedAt.isNull(),
@@ -52,7 +52,7 @@ public class TestResultRepositoryImpl implements TestResultRepositoryCustom {
         List<Tuple> tuples = queryFactory
                 .select(tr.status, tr.count())
                 .from(tr)
-                .join(te).on(tr.testExecution.executionId.eq(te.executionId))
+                .join(tr.testExecution, te)
                 .where(
                         te.projectId.eq(projectId),
                         te.deletedAt.isNull(),
@@ -69,6 +69,7 @@ public class TestResultRepositoryImpl implements TestResultRepositoryCustom {
         List<Tuple> tuples = queryFactory
                 .select(tr.status, tr.count())
                 .from(tr)
+                .join(tr.testExecution, te)
                 .where(
                         tr.testExecution.executionId.eq(executionId),
                         te.deletedAt.isNull(),
@@ -90,8 +91,10 @@ public class TestResultRepositoryImpl implements TestResultRepositoryCustom {
         List<Tuple> results = queryFactory
                 .select(tr.testExecution.executionId, tr.status, tr.count())
                 .from(tr)
+                .join(tr.testExecution, te)
                 .where(
                         tr.testExecution.executionId.in(executionIds),
+                        te.deletedAt.isNull(), // Execution 자체가 삭제된 경우 카운트 제외
                         tr.deletedAt.isNull() // Soft Delete 필터링
                 )
                 .groupBy(tr.testExecution.executionId, tr.status)
@@ -99,13 +102,15 @@ public class TestResultRepositoryImpl implements TestResultRepositoryCustom {
 
         // 결과를 Map<Long, Map<ResultStatus, Long>> 형태로 변환
         // 예: {1L: {PASS: 10, FAIL: 2}, 2L: {PASS: 5, BLOCK: 1}}
-        return results.stream().collect(Collectors.groupingBy(
-                t -> t.get(tr.testExecution.executionId),
-                Collectors.toMap(
-                        t -> t.get(tr.status),
-                        t -> t.get(tr.count())
-                )
-        ));
+        return results.stream()
+                .filter(t -> t.get(tr.testExecution.executionId) != null && t.get(tr.status) != null)
+                .collect(Collectors.groupingBy(
+                        t -> Objects.requireNonNull(t.get(tr.testExecution.executionId)),
+                        Collectors.toMap(
+                                t -> Objects.requireNonNull(t.get(tr.status)),
+                                t -> Objects.requireNonNullElse(t.get(tr.count()), 0L)
+                        )
+                ));
     }
 
     private Map<ResultStatus, Long> toStatusMap(List<Tuple> tuples) {
@@ -114,7 +119,12 @@ public class TestResultRepositoryImpl implements TestResultRepositoryCustom {
             map.put(s, 0L);
         }
         for (Tuple tuple : tuples) {
-            map.put(tuple.get(tr.status), tuple.get(tr.count()));
+            ResultStatus status = tuple.get(tr.status);
+            Long count = tuple.get(tr.count());
+            // Null 반환 방지 및 안전한 맵 주입
+            if (status != null) {
+                map.put(status, Objects.requireNonNullElse(count, 0L));
+            }
         }
         return map;
     }

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestResultRepositoryImpl.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/repository/TestResultRepositoryImpl.java
@@ -29,7 +29,7 @@ public class TestResultRepositoryImpl implements TestResultRepositoryCustom {
         return queryFactory
                 .selectFrom(tr)
                 .where(
-                        tr.executionId.eq(executionId),
+                        tr.testExecution.executionId.eq(executionId),
                         tr.deletedAt.isNull()
                 )
                 .orderBy(buildOrderSpecifier(sortField, ascending))
@@ -53,7 +53,7 @@ public class TestResultRepositoryImpl implements TestResultRepositoryCustom {
         List<Tuple> tuples = queryFactory
                 .select(tr.status, tr.count())
                 .from(tr)
-                .join(te).on(tr.executionId.eq(te.executionId))
+                .join(te).on(tr.testExecution.executionId.eq(te.executionId))
                 .where(
                         te.projectId.eq(projectId),
                         te.deletedAt.isNull(),
@@ -71,7 +71,7 @@ public class TestResultRepositoryImpl implements TestResultRepositoryCustom {
                 .select(tr.status, tr.count())
                 .from(tr)
                 .where(
-                        tr.executionId.eq(executionId),
+                        tr.testExecution.executionId.eq(executionId),
                         tr.deletedAt.isNull()
                 )
                 .groupBy(tr.status)

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/service/TestService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/service/TestService.java
@@ -1,0 +1,234 @@
+package com.graduationCapstone.Probe.domain.test.service;
+
+import com.graduationCapstone.Probe.domain.agent.service.AgentDispatchService;
+import com.graduationCapstone.Probe.domain.test.dto.*;
+import com.graduationCapstone.Probe.domain.test.entity.*;
+import com.graduationCapstone.Probe.domain.test.repository.*;
+import com.graduationCapstone.Probe.domain.user.entity.User;
+import com.graduationCapstone.Probe.global.exception.ErrorCode;
+import com.graduationCapstone.Probe.global.exception.handler.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TestService {
+
+    private final TestGroupRepository groupRepo;
+    private final TestExecutionRepository executionRepo;
+    private final TestResultRepository resultRepo;
+    private final AgentDispatchService agentDispatchService;
+
+    /**
+     * 사용자가 입력한 그룹명으로 바구니를 만들고, 에이전트에게 개별 테스트 생성을 위임합니다.
+     * 시나리오가 1개여도 동일한 '그룹화' 과정을 거칩니다.
+     */
+    @Transactional
+    public void createTestEntities(User user, Long projectId, TestGroupCreateRequestDto dto) {
+        log.info("[FLOW] 테스트 그룹 생성 및 실행 시작 - ProjectID: {}, Group: {}", projectId, dto.baseTestGroupName());
+
+        // 사용자가 입력한 그룹명으로 TestGroup을 먼저 저장합니다.
+        TestGroup group = groupRepo.save(TestGroup.builder()
+                .projectId(projectId)
+                .groupName(dto.baseTestGroupName())
+                .targetRepoId(dto.targetRepoId())
+                .targetBranch(dto.targetBranch())
+                .build());
+
+        // 선택된 시나리오 리스트를 순회하며 에이전트에게 생성/발송을 요청합니다.
+        for (Long sId : dto.scenarioIds()) {
+            ScenarioSerial serialInfo = ScenarioSerial.values()[sId.intValue() - 1];
+
+            // AgentDispatchService가 스스로 TestExecution을 생성하고 AI에 요청을 보냅니다.
+            // 여기서는 그 결과로 만들어진 ID만 받습니다. (시퀀스 중복 방지)
+            Long executionId = agentDispatchService.dispatchPlan(
+                    user,
+                    projectId,
+                    sId,
+                    serialInfo.getTestItem(),
+                    dto.targetBranch()
+            );
+
+            // 에이전트가 만든 실행 엔티티를 찾아 그룹과 이름을 동기화합니다.
+            TestExecution execution = executionRepo.findById(executionId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+            // 테스트 그룹 엔티티와 그룹명 스냅샷을 강제로 주입하여 교정합니다.
+            execution.updateGroupAndName(group, group.getGroupName());
+
+            log.info("[FLOW] 에이전트 요청 완료 및 후처리 성공 - ExecutionID: {}, Scenario: {}",
+                    executionId, serialInfo.getTestItem());
+        }
+        log.info("[FLOW] 모든 시나리오에 대한 그룹 테스트 요청 완료");
+    }
+
+    /**
+     * 테스트 그룹명을 수정하고, 해당 그룹에 속한 모든 테스트 코드(Execution)의 testName 스냅샷을 동기화합니다.
+     */
+    @Transactional
+    public void updateGroupName(Long projectId, Long groupId, String newName) {
+        log.info("[UPDATE] 테스트 그룹명 수정 요청 - GroupID: {}, NewName: {}", groupId, newName);
+
+        TestGroup group = groupRepo.findById(groupId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        if (!group.getProjectId().equals(projectId)) {
+            log.warn("[SECURITY] 권한 없는 프로젝트 테스트 그룹 수정 시도 - ProjectID: {}, GroupID: {}", projectId, groupId);
+            throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        }
+
+        group.updateGroupName(newName);
+
+        // 하위 모든 테스트 코드의 testName(스냅샷)을 새 그룹명으로 일괄 변경
+        List<TestExecution> executions = executionRepo.findAllByTestGroup_GroupId((groupId));
+        for (TestExecution exec : executions) {
+            exec.updateTestName(newName);
+        }
+
+        log.info("[UPDATE] 테스트 그룹 및 하위 테스트 코드명 수정 완료 - Affected Count: {}", executions.size());
+    }
+
+    /**
+     * 테스트 그룹을 삭제합니다.
+     */
+    @Transactional
+    public void deleteGroup(Long projectId, Long groupId) {
+        log.info("[DELETE] 테스트 그룹 삭제 요청 - GroupID: {}", groupId);
+
+        TestGroup group = groupRepo.findById(groupId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        if (!group.getProjectId().equals(projectId)) {
+            throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        }
+
+        groupRepo.delete(group);
+        log.info("[DELETE] 테스트 그룹 삭제 완료 - GroupID: {}", groupId);
+    }
+
+    /**
+     * 프로젝트 내 테스트 그룹 이름 중복 여부를 확인합니다.
+     */
+    @Transactional(readOnly = true)
+    public boolean isGroupNameDuplicate(Long projectId, String groupName) {
+        return groupRepo.existsByProjectIdAndGroupName(projectId, groupName);
+    }
+
+    /**
+     * 기본 목록 조회 및 정렬
+     */
+    @Transactional(readOnly = true)
+    public List<TestExecutionListDto> getBasicSortedList(Long projectId, String field, boolean ascending) {
+        log.info("[LIST] 기본 목록 조회 - Field: {}, Asc: {}", field, ascending);
+        return executionRepo.findAllActiveByProjectId(projectId, field, ascending).stream()
+                .map(e -> new TestExecutionListDto(
+                        e.getTestScenarioId(),
+                        e.getTestName(),
+                        e.getStatus().name(),
+                        formatDuration(e.getDurationSeconds()),
+                        e.getTesterName(),
+                        e.getCompletedAt()
+                )).toList();
+    }
+
+    /**
+     * 정렬 기준에 따라 테스트 요약 목록을 조회합니다.
+     */
+    @Transactional(readOnly = true)
+    public List<TestCaseSummaryDto> getTestSummaryList(Long projectId, String sortField, boolean ascending) {
+        log.info("[LIST] 요약 목록 조회 - Sort: {}", sortField);
+        return executionRepo.findAllActiveByProjectId(projectId, sortField, ascending).stream()
+                .flatMap(exec -> exec.getTestResults().stream()
+                        .filter(res -> res.getDeletedAt() == null)
+                        .map(res -> {
+                            PassRateResponseDto stats = getPassRateStats(exec.getExecutionId());
+                            return new TestCaseSummaryDto(
+                                    res.getFullTestCaseId(),
+                                    exec.getTestGroup().getGroupName(),
+                                    stats.passRatio(),
+                                    formatDuration(res.getDurationSeconds()),
+                                    exec.getTesterName(),
+                                    exec.getCompletedAt()
+                            );
+                        })
+                ).toList();
+    }
+
+    /**
+     * 프로젝트 전체의 테스트 통과 비율을 조회합니다.
+     */
+    @Transactional(readOnly = true)
+    public PassRateResponseDto getProjectGlobalStats(Long projectId) {
+        Map<ResultStatus, Long> counts = resultRepo.countByStatusForProject(projectId);
+        long pass = counts.getOrDefault(ResultStatus.PASS, 0L);
+        long total = counts.values().stream().mapToLong(l -> l).sum();
+
+        String countString = pass + "/" + total;
+        return new PassRateResponseDto(pass, total, countString, calculateRatio(pass, total));
+    }
+
+    /**
+     * 특정 테스트 코드(Execution)의 통과 비율을 계산합니다.
+     */
+    @Transactional(readOnly = true)
+    public PassRateResponseDto getPassRateStats(Long executionId) {
+        Map<ResultStatus, Long> counts = resultRepo.countByStatusForExecution(executionId);
+        long pass = counts.getOrDefault(ResultStatus.PASS, 0L);
+        long total = counts.values().stream().mapToLong(l -> l).sum();
+
+        String countString = pass + "/" + total;
+        return new PassRateResponseDto(pass, total, countString, calculateRatio(pass, total));
+    }
+
+    /**
+     * 통과된 테스트의 비율을 소수점 첫째 자리까지 계산하여 문자열로 반환합니다.
+     */
+    public String calculateRatio(long pass, long total) {
+        if (total == 0) return "0.0%";
+        double ratio = (double) pass / total * 100;
+        return String.format("%.1f%%", Math.round(ratio * 10.0) / 10.0);
+    }
+
+    /**
+     * 소요 시간(초)을 문자열로 변환합니다.
+     */
+    public String formatDuration(Double sec) {
+        if (sec == null || sec == 0) return "0s";
+        int totalSec = sec.intValue();
+        int minutes = totalSec / 60;
+        int seconds = totalSec % 60;
+        return (minutes == 0) ? seconds + "s" : String.format("%dm %ds", minutes, seconds);
+    }
+
+    /**
+     * 날짜별 평균 테스트 시간 조회
+     */
+    @Transactional(readOnly = true)
+    public List<DailyAvgDurationResponseDto> getDailyAvgDurations(Long projectId) {
+        return executionRepo.findDailyAvgDuration(projectId).stream()
+                .map(t -> new DailyAvgDurationResponseDto(t.get(0, String.class), formatDuration(t.get(1, Double.class))))
+                .toList();
+    }
+
+    /**
+     * 프로젝트 내의 테스트 케이스(Execution) 총 개수 조회
+     */
+    @Transactional(readOnly = true)
+    public long countTotalExecutions(Long projectId) {
+        return executionRepo.countByProjectId(projectId);
+    }
+
+    /**
+     * 특정 테스트 그룹에 포함된 모든 하위 결과의 총 개수 집계
+     */
+    @Transactional(readOnly = true)
+    public long countResultsInGroup(Long groupId) {
+        return resultRepo.countByTestExecution_TestGroup_GroupId(groupId);
+    }
+}

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/service/TestService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/service/TestService.java
@@ -43,7 +43,7 @@ public class TestService {
 
         // 선택된 시나리오 리스트를 순회하며 에이전트에게 생성/발송을 요청합니다.
         for (Long sId : dto.scenarioIds()) {
-            ScenarioSerial serialInfo = ScenarioSerial.values()[sId.intValue() - 1];
+            ScenarioSerial serialInfo = ScenarioSerial.fromCode(String.format("%02d", sId));
 
             // AgentDispatchService가 스스로 TestExecution을 생성하고 AI에 요청을 보냅니다.
             // 여기서는 그 결과로 만들어진 ID만 받습니다. (시퀀스 중복 방지)
@@ -142,16 +142,27 @@ public class TestService {
      */
     @Transactional(readOnly = true)
     public List<TestCaseSummaryDto> getTestSummaryList(Long projectId, String sortField, boolean ascending) {
-        log.info("[LIST] 요약 목록 조회 - Sort: {}", sortField);
-        return executionRepo.findAllActiveByProjectId(projectId, sortField, ascending).stream()
+        List<TestExecution> executions = executionRepo.findAllActiveByProjectId(projectId, sortField, ascending);
+        if (executions.isEmpty()) return List.of();
+
+        // 루프 밖에서 한 번의 쿼리로 모든 통계 데이터를 땡겨옵니다. [N+1 문제 방지]
+        List<Long> execIds = executions.stream().map(TestExecution::getExecutionId).toList();
+        Map<Long, Map<ResultStatus, Long>> batchStats = resultRepo.findCountsByExecutionIds(execIds);
+
+        return executions.stream()
                 .flatMap(exec -> exec.getTestResults().stream()
-                        .filter(res -> res.getDeletedAt() == null)
+                        .filter(res -> !res.isDeleted())
                         .map(res -> {
-                            PassRateResponseDto stats = getPassRateStats(exec.getExecutionId());
+                            Map<ResultStatus, Long> counts = batchStats.getOrDefault(exec.getExecutionId(), Map.of());
+
+                            long pass = counts.getOrDefault(ResultStatus.PASS, 0L);
+                            long total = counts.values().stream().mapToLong(l -> l).sum();
+                            String passRatio = calculateRatio(pass, total);
+
                             return new TestCaseSummaryDto(
                                     res.getFullTestCaseId(),
                                     exec.getTestGroup().getGroupName(),
-                                    stats.passRatio(),
+                                    passRatio,
                                     formatDuration(res.getDurationSeconds()),
                                     exec.getTesterName(),
                                     exec.getCompletedAt()
@@ -221,7 +232,7 @@ public class TestService {
      */
     @Transactional(readOnly = true)
     public long countTotalExecutions(Long projectId) {
-        return executionRepo.countByProjectId(projectId);
+        return executionRepo.countByProjectIdAndDeletedAtIsNull(projectId);
     }
 
     /**
@@ -229,6 +240,6 @@ public class TestService {
      */
     @Transactional(readOnly = true)
     public long countResultsInGroup(Long groupId) {
-        return resultRepo.countByTestExecution_TestGroup_GroupId(groupId);
+        return resultRepo.countByTestExecution_TestGroup_GroupIdAndDeletedAtIsNull(groupId);
     }
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/service/TestService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/service/TestService.java
@@ -79,19 +79,11 @@ public class TestService {
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
 
         if (!group.getProjectId().equals(projectId)) {
-            log.warn("[SECURITY] 권한 없는 프로젝트 테스트 그룹 수정 시도 - ProjectID: {}, GroupID: {}", projectId, groupId);
-            throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
         }
 
         group.updateGroupName(newName);
-
-        // 하위 모든 테스트 코드의 testName(스냅샷)을 새 그룹명으로 일괄 변경
-        List<TestExecution> executions = executionRepo.findAllByTestGroup_GroupId((groupId));
-        for (TestExecution exec : executions) {
-            exec.updateTestName(newName);
-        }
-
-        log.info("[UPDATE] 테스트 그룹 및 하위 테스트 코드명 수정 완료 - Affected Count: {}", executions.size());
+        log.info("[UPDATE] 테스트 그룹명 수정 완료 (과거 실행 스냅샷은 유지됨) - GroupID: {}", groupId);
     }
 
     /**
@@ -108,8 +100,8 @@ public class TestService {
             throw new CustomException(ErrorCode.INVALID_ARGUMENT);
         }
 
-        groupRepo.delete(group);
-        log.info("[DELETE] 테스트 그룹 삭제 완료 - GroupID: {}", groupId);
+        group.softDelete();
+        log.info("[DELETE] 테스트 그룹 및 하위 실행/결과 Soft Delete 완료 - GroupID: {}", groupId);
     }
 
     /**
@@ -142,7 +134,7 @@ public class TestService {
      */
     @Transactional(readOnly = true)
     public List<TestCaseSummaryDto> getTestSummaryList(Long projectId, String sortField, boolean ascending) {
-        List<TestExecution> executions = executionRepo.findAllActiveByProjectId(projectId, sortField, ascending);
+        List<TestExecution> executions = executionRepo.findAllActiveWithResultsByProjectId(projectId, sortField, ascending);
         if (executions.isEmpty()) return List.of();
 
         // 루프 밖에서 한 번의 쿼리로 모든 통계 데이터를 땡겨옵니다. [N+1 문제 방지]
@@ -159,9 +151,13 @@ public class TestService {
                             long total = counts.values().stream().mapToLong(l -> l).sum();
                             String passRatio = calculateRatio(pass, total);
 
+                            String displayName = (exec.getTestGroup() != null)
+                                    ? exec.getTestGroup().getGroupName()
+                                    : exec.getTestName(); // 그룹 정보가 없으면 실행 시점의 스냅샷 명칭 사용
+
                             return new TestCaseSummaryDto(
                                     res.getFullTestCaseId(),
-                                    exec.getTestGroup().getGroupName(),
+                                    displayName,
                                     passRatio,
                                     formatDuration(res.getDurationSeconds()),
                                     exec.getTesterName(),


### PR DESCRIPTION
## 📝 PR 설명
사용자가 입력하는 테스트명(테스트그룹)을 중심으로 여러 시나리오를 통합 관리할 수 있도록 테스트 관리 대시보드 API를 구현하였습니다.

## 🛠 주요 변경 사항
- 그룹 기반 테스트 오케스트레이션 로직 구현
  - TestService를 통해 TestGroup 생성 후 AgentDispatchService에 실행을 위임하는 아키텍처 구축
- 데이터 일관성을 위한 스냅샷 전략 적용
  - 테스트 실행 시점의 테스트그룹명을 TestExecution에 스냅샷으로 저장하여 그룹명 변경 시에도 과거 기록 유지



-  프로젝트 내의 레포지토리 중 선택하고 시나리오를 선택한 뒤 테스트 그룹명 생성(한개만 선택하면 ‘입력한 테스트그룹명’ 그대로 저장하고, 만약 다중 시나리오 선택 시 ‘입력한 테스트그룹명’+’(시나리오 가이드명)’으로 생성(예시: ‘회원관련 테스트’로 입력 후 회원가입, 로그인이라는 2개의 시나리오를 선택했으면 ‘회원관련 테스트(회원가입)’, ‘회원관련 테스트(로그인)’ 두 개의 테스트그룹이 생성됨) 및 테스트그룹명(엔티티 내용) 대한 수정,삭제(논리적 삭제 미구현),조회 API
- 프로젝트 내 테스트그룹명 중복체크 API 
- 테스트그룹 내의 레포지토리 검색 API 
- 테스트케이스ID(T[SCENARIO_SERIAL][SCENARIO_ATTEMPT]_[testCaseNumber]), testCodename(테스트 코드명), 상태(status), 테스트 시간(durationSeconds), 테스터(tester), 일시(completedAt) 를 보여주는 API 구현 및 각각의 항목들(테스트케이스ID(T[SCENARIO_SERIAL][SCENARIO_ATTEMPT]_[testCaseNumber]), testCodename(테스트 코드명), 상태(status), 테스트 시간(durationSeconds), 테스터(tester), 일시(completedAt))에 대해 오름차순, 내림차순 정렬 API(필드에 값을 넣어 정렬 기준 설정)
- 테스트 코드(testCodeName) 이름 수정 및 테스트 코드 항목 삭제 API 
- 원하는 테스트케이스의 테스트 계획서 다운로드 할 수 있는 API
- 원하는 테스트케이스의 테스트 결과 보고서 다운로드 할 수 있는 API
- 원하는 테스트케이스의 각 테스트 코드를 선택 시 테스터, 상태(status), 완료 시간(completedAt),에러 메시지(Pass면 null)을 보여주는 API, 테스터, 상태와 완료 시간(completedAt),테스트 코드(testCode)를 보여주는 API, 테스터,상태와 완료 시간(completedAt),테스트 시나리오명(scenarioName), 설명(description), 테스트케이스ID(testCodeId), 테스트케이스명(testCaseName), 전제 조건(precondition), 테스트 데이터(testData), 실행단계(executionSteps), 결과(result)를 보여주는 API, 상태와 Playwright 스크린샷(screenshotS3Urls)를 보여주는 API
- 해당 테스트 케이스 내에서 각 상태(Pass, Block, Fail, Untest) 개수와 전체 상태 개수 중에서 Pass의 개수(예시:47/50)와 비율(예시:77.1%)을 반올림하여 소수점 한자리까지만 보여주는 API
- 테스트케이스ID(T[SCENARIO_SERIAL][SCENARIO_ATTEMPT]_[testCaseNumber]), testCodename(테스트 코드명), 테스트그룹명, 해당 테스트그룹의 Pass 비율(반올림하여소수점 한자리까지 표시),테스트 시간, 테스터, 일시(completedAt)을 보여주는 API 및 각각의 항목들에 대해 오름차순, 내림차순 정렬 API
- 프로젝트 내의 모든 테스트그룹들에 대해 yyyy-mm-dd 형식으로(시,분 단위 제외) 해당 날짜의  테스트 시간의 평균(예시: 4m 30s)을 분,초 단위로 보여주는 API
- 프로젝트 내의 모든 테스트그룹들 안에 있는 테스트 코드들의 각각의 상태들의 개수 및 전체 상태 개수 중에서 Pass의 개수(예시:47/50)와 비율(예시:77.1%)을 반올림하여 소수점 한자리까지만 보여주는 API
- 프로젝트 내 테스트 케이스 총 개수 보여주는 API 
- 테스트그룹 내 테스트 코드 총 개수 보여주는 API

## 🧪 테스트 체크리스트

## 📸 스크린샷 또는 비디오

## ➕ 추가 사항

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다
- [ ] 불필요한 코드를 제거했습니다
- [ ] 주석 처리를 필요한 만큼 하였습니다.
- [ ] PR 제목 또는 설명에 Jira 이슈 키를 포함했습니다

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
