### PR TITLE
[Cst-97] fix: 프로젝트 생성 시 레포지토리 정보 저장 에러 및 테스트 그룹 생성 시 인자 변경

### DIFF
--- a/src/main/java/com/graduationCapstone/Probe/domain/agent/controller/AgentController.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/agent/controller/AgentController.java
@@ -50,7 +50,7 @@ public class AgentController {
         Long executionId = agentDispatchService.dispatchPlan(
                 user,
                 requestDto.projectId(),
-                requestDto.scenarioId(),
+                requestDto.scenarioSerial(),
                 requestDto.testItem(),
                 requestDto.targetBranch()
         );

--- a/src/main/java/com/graduationCapstone/Probe/domain/agent/dto/AgentPlanTriggerRequestDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/agent/dto/AgentPlanTriggerRequestDto.java
@@ -12,8 +12,8 @@ public record AgentPlanTriggerRequestDto(
         @NotNull(message = "프로젝트 ID는 필수입니다.")
         Long projectId,
 
-        @NotNull(message = "시나리오 ID는 필수입니다.")
-        Long scenarioId,
+        @NotNull(message = "시나리오 시리얼는 필수입니다.")
+        String scenarioSerial,
 
         @NotBlank(message = "시나리오 가이드 이름은 필수입니다.")
         String testItem,        // 예: "회원가입", "로그인"

--- a/src/main/java/com/graduationCapstone/Probe/domain/agent/service/AgentDispatchService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/agent/service/AgentDispatchService.java
@@ -65,20 +65,22 @@ public class AgentDispatchService {
      *
      * @param user         현재 인증된 사용자
      * @param projectId    프로젝트 ID
-     * @param scenarioId   시나리오 ID
+     * @param scenarioSerial   시나리오시리얼 번호
      * @param testItem     시나리오 가이드 이름 (예: "회원가입")
      * @param targetBranch 테스트 대상 브랜치
      * @return 생성된 TestExecution의 ID
      */
     @Transactional
-    public Long dispatchPlan(User user, Long projectId, Long scenarioId,
+    public Long dispatchPlan(User user, Long projectId, String scenarioSerial,
                              String testItem, String targetBranch) {
-        log.info("Dispatching plan. ProjectId={}, TestItem={}", projectId, testItem);
+        log.info("Dispatching plan. ProjectId={}, Serial={}, TestItem={}", projectId, scenarioSerial, testItem);
 
         // 1. 시나리오 시리얼 조회
-        ScenarioSerial serial = ScenarioSerial.fromTestItem(testItem);
+        Scenario scenario = scenarioRepository.findByProjectIdAndScenarioSerial(projectId, scenarioSerial)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
 
         // 2. SCENARIO_ATTEMPT 발급 (동시성 제어)
+        ScenarioSerial serial = ScenarioSerial.fromTestItem(testItem);
         ScenarioSequence sequence = scenarioSequenceRepository
                 .findByProjectIdAndScenarioSerialForUpdate(projectId, serial.getCode())
                 .orElseGet(() -> scenarioSequenceRepository.save(
@@ -108,11 +110,11 @@ public class AgentDispatchService {
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
 
         // 5. Scenario (auth_token) 조회
-        Scenario scenario = scenarioRepository.findById(scenarioId)
-                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+//        Scenario scenario = scenarioRepository.findById(scenarioId)
+//                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
 
         // 6. 시나리오 스텝에서 requirement 구성
-        List<ScenarioGuide> steps = scenarioGuideRepository.findAllByScenarioIdOrderByStepOrder(scenarioId);
+        List<ScenarioGuide> steps = scenarioGuideRepository.findAllByScenarioIdOrderByStepOrder(scenario.getScenarioId());
         if (steps.isEmpty()) {
             throw new CustomException(ErrorCode.INVALID_ARGUMENT);
         }

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/repository/GithubRepositoryRepository.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/repository/GithubRepositoryRepository.java
@@ -6,5 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface GithubRepositoryRepository extends JpaRepository<GithubRepository, Long> {
+    void deleteByProjectId(Long projectId);
     Optional<GithubRepository> findByProjectId(Long projectId);
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/repository/ScenarioRepository.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/repository/ScenarioRepository.java
@@ -3,5 +3,8 @@ package com.graduationCapstone.Probe.domain.project.repository;
 import com.graduationCapstone.Probe.domain.project.entity.Scenario;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ScenarioRepository extends JpaRepository<Scenario, Long> {
+    Optional<Scenario> findByProjectIdAndScenarioSerial(Long projectId, String scenarioSerial);
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/service/ProjectService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/service/ProjectService.java
@@ -40,6 +40,7 @@ public class ProjectService {
     private final GithubRepoRepository githubRepoRepository;
     private final UserRepository userRepository;
     private final ProjectRepoRepository projectRepoRepository;
+    private final GithubRepositoryRepository githubRepositoryRepository;
 
     private final ScenarioRepository scenarioRepository;
     private final ScenarioGuideRepository scenarioGuideRepository;
@@ -87,6 +88,8 @@ public class ProjectService {
                                     .build();
                             project.addMember(member);
 
+                            Project savedProject = projectRepository.save(project);
+
                             if (request.repoIds() != null && !request.repoIds().isEmpty()) {
                                 List<GithubRepo> repos = githubRepoRepository.findAllById(request.repoIds());
 
@@ -99,9 +102,20 @@ public class ProjectService {
                                             .githubRepo(repo)
                                             .build();
                                     project.addProjectRepo(pr);
+
+                                    // 테스트 시스템용 github_repository 테이블 저장
+                                    GithubRepository gr = GithubRepository.builder()
+                                            .projectId(savedProject.getId())
+                                            .repoUrl("https://github.com/" + repo.getOwner() + "/" + repo.getRepoName())
+                                            .visibility(repo.isPublic() ? "PUBLIC" : "PRIVATE")
+                                            .starCount(repo.getStargazersCount())
+                                            .forkCount(repo.getForksCount())
+                                            .githubUpdatedAt(repo.getUpdatedAt())
+                                            .build();
+                                    githubRepositoryRepository.save(gr);
                                 }
                             }
-                            Project savedProject = projectRepository.save(project);
+
                             initializeDefaultScenarios(savedProject); // 기본 시나리오 자동 생성 호출
                             log.info("프로젝트 생성 성공: id={}", savedProject.getId());
                             return ProjectResponseDto.from(savedProject);
@@ -487,6 +501,7 @@ public class ProjectService {
             validateOwner(projectId, userId);
 
             project.getProjectRepos().clear();
+            githubRepositoryRepository.deleteByProjectId(projectId); //기존 데이터 삭제(github_repository 테이블 동기화)
 
             if (newRepoIds != null && !newRepoIds.isEmpty()) {
                 List<GithubRepo> repos = githubRepoRepository.findAllById(newRepoIds);
@@ -501,6 +516,17 @@ public class ProjectService {
                             .githubRepo(repo)
                             .build();
                     project.addProjectRepo(pr);
+
+                    // 테스트 데이터 저장
+                    GithubRepository gr = GithubRepository.builder()
+                            .projectId(projectId)
+                            .repoUrl("https://github.com/" + repo.getOwner() + "/" + repo.getRepoName())
+                            .visibility(repo.isPublic() ? "PUBLIC" : "PRIVATE")
+                            .starCount(repo.getStargazersCount())
+                            .forkCount(repo.getForksCount())
+                            .githubUpdatedAt(repo.getUpdatedAt())
+                            .build();
+                    githubRepositoryRepository.save(gr);
                 }
             }
             projectRepository.save(project);

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestGroupCreateRequestDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestGroupCreateRequestDto.java
@@ -13,7 +13,7 @@ public record TestGroupCreateRequestDto(
         Long targetRepoId,
 
         @NotEmpty(message = "최소 하나 이상의 시나리오를 선택해야 합니다.")
-        List<Long> scenarioIds,
+        List<String> scenarioSerials,
 
         @NotBlank(message = "대상 브랜치는 필수입니다.")
         String targetBranch

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/service/TestService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/service/TestService.java
@@ -42,15 +42,15 @@ public class TestService {
                 .build());
 
         // 선택된 시나리오 리스트를 순회하며 에이전트에게 생성/발송을 요청합니다.
-        for (Long sId : dto.scenarioIds()) {
-            ScenarioSerial serialInfo = ScenarioSerial.fromCode(String.format("%02d", sId));
+        for (String serial : dto.scenarioSerials()) {
+            ScenarioSerial serialInfo = ScenarioSerial.fromCode(serial);
 
             // AgentDispatchService가 스스로 TestExecution을 생성하고 AI에 요청을 보냅니다.
             // 여기서는 그 결과로 만들어진 ID만 받습니다. (시퀀스 중복 방지)
             Long executionId = agentDispatchService.dispatchPlan(
                     user,
                     projectId,
-                    sId,
+                    serial,
                     serialInfo.getTestItem(),
                     dto.targetBranch()
             );

--- a/src/test/java/com/graduationCapstone/Probe/domain/agent/service/AgentDispatchServiceTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/domain/agent/service/AgentDispatchServiceTest.java
@@ -107,7 +107,7 @@ class AgentDispatchServiceTest {
         void dispatchPlan_success() throws InterruptedException {
             // given
             Long projectId = 100L;
-            Long scenarioId = 1L;
+            String scenarioSerial = "01";
             String testItem = "회원가입";
             String targetBranch = "feature/login";
 
@@ -134,30 +134,31 @@ class AgentDispatchServiceTest {
             given(githubRepositoryRepository.findByProjectId(projectId)).willReturn(Optional.of(mockRepo));
 
             Scenario mockScenario = Scenario.builder()
-                    .scenarioId(scenarioId)
+                    .scenarioId(1L)
                     .authToken("Bearer test-token-123")
                     .build();
-            given(scenarioRepository.findById(scenarioId)).willReturn(Optional.of(mockScenario));
+            given(scenarioRepository.findByProjectIdAndScenarioSerial(projectId, scenarioSerial)).willReturn(Optional.of(mockScenario));
 
             Guide mockGuide = Guide.builder().testItem("회원가입 버튼을 누른다").build();
             ScenarioGuide mockScenarioGuide = ScenarioGuide.builder()
                     .stepOrder(1)
                     .guide(mockGuide)
                     .build();
-            given(scenarioGuideRepository.findAllByScenarioIdOrderByStepOrder(scenarioId))
+            given(scenarioGuideRepository.findAllByScenarioIdOrderByStepOrder(1L))
                     .willReturn(List.of(mockScenarioGuide));
 
             mockWebServer.enqueue(new MockResponse().setResponseCode(202));
 
             // when
             Long executionId = agentDispatchService.dispatchPlan(
-                    testUser, projectId, scenarioId, testItem, targetBranch);
+                    testUser, projectId, scenarioSerial, testItem, targetBranch);
 
             // then — TestExecution 생성 확인
             ArgumentCaptor<TestExecution> executionCaptor = ArgumentCaptor.forClass(TestExecution.class);
             verify(testExecutionRepository).save(executionCaptor.capture());
             TestExecution savedExecution = executionCaptor.getValue();
 
+            assertThat(executionId).isEqualTo(1L);
             assertThat(savedExecution.getProjectId()).isEqualTo(projectId);
             assertThat(savedExecution.getTester()).isEqualTo(testUser);
             assertThat(savedExecution.getTesterName()).isEqualTo("tester");
@@ -188,7 +189,7 @@ class AgentDispatchServiceTest {
         void dispatchPlan_existingSequence_incrementsAttempt() {
             // given
             Long projectId = 100L;
-            Long scenarioId = 1L;
+            String scenarioSerial = "01";
 
             ScenarioSequence existingSequence = ScenarioSequence.builder()
                     .projectId(projectId)
@@ -210,18 +211,18 @@ class AgentDispatchServiceTest {
                     .build();
             given(githubRepositoryRepository.findByProjectId(projectId)).willReturn(Optional.of(mockRepo));
 
-            Scenario mockScenario = Scenario.builder().scenarioId(scenarioId).build();
-            given(scenarioRepository.findById(scenarioId)).willReturn(Optional.of(mockScenario));
+            Scenario mockScenario = Scenario.builder().scenarioId(1L).build();
+            given(scenarioRepository.findByProjectIdAndScenarioSerial(projectId, scenarioSerial)).willReturn(Optional.of(mockScenario));
 
             Guide mockGuide = Guide.builder().testItem("회원가입").build();
             ScenarioGuide sg = ScenarioGuide.builder().stepOrder(1).guide(mockGuide).build();
-            given(scenarioGuideRepository.findAllByScenarioIdOrderByStepOrder(scenarioId))
+            given(scenarioGuideRepository.findAllByScenarioIdOrderByStepOrder(1L))
                     .willReturn(List.of(sg));
 
             mockWebServer.enqueue(new MockResponse().setResponseCode(202));
 
             // when
-            agentDispatchService.dispatchPlan(testUser, projectId, scenarioId, "회원가입", "main");
+            agentDispatchService.dispatchPlan(testUser, projectId, scenarioSerial, "회원가입", "main");
 
             // then — attempt가 4로 증가
             ArgumentCaptor<TestExecution> captor = ArgumentCaptor.forClass(TestExecution.class);
@@ -235,7 +236,7 @@ class AgentDispatchServiceTest {
         void dispatchPlan_unknownTestItem_throwsException() {
             // when & then
             assertThatThrownBy(() -> agentDispatchService.dispatchPlan(
-                    testUser, 100L, 1L, "존재하지 않는 시나리오", "main"))
+                    testUser, 100L, "01", "존재하지 않는 시나리오", "main"))
                     .isInstanceOf(IllegalArgumentException.class);
         }
 
@@ -244,13 +245,17 @@ class AgentDispatchServiceTest {
         void dispatchPlan_repoNotFound_throwsException() {
             // given
             Long projectId = 100L;
-            Long scenarioId = 1L;
+            String scenarioSerial = "01";
 
-            ScenarioSequence seq = ScenarioSequence.builder()
-                    .projectId(projectId).scenarioSerial("01").build();
-            given(scenarioSequenceRepository.findByProjectIdAndScenarioSerialForUpdate(projectId, "01"))
+            given(scenarioSequenceRepository.findByProjectIdAndScenarioSerialForUpdate(projectId, scenarioSerial))
                     .willReturn(Optional.empty());
-            given(scenarioSequenceRepository.save(any(ScenarioSequence.class))).willReturn(seq);
+            given(scenarioSequenceRepository.save(any(ScenarioSequence.class))).willReturn(ScenarioSequence.builder().projectId(projectId).scenarioSerial(scenarioSerial).build());
+
+            // 시나리오 조회는 성공하지만 레포지토리 조회가 실패하는 상황
+            Scenario mockScenario = Scenario.builder().scenarioId(1L).build();
+            given(scenarioRepository.findByProjectIdAndScenarioSerial(projectId, scenarioSerial))
+                    .willReturn(Optional.of(mockScenario));
+
             given(testExecutionRepository.save(any(TestExecution.class))).willAnswer(invocation -> {
                 TestExecution te = invocation.getArgument(0);
                 ReflectionTestUtils.setField(te, "executionId", 1L);
@@ -260,7 +265,7 @@ class AgentDispatchServiceTest {
 
             // when & then
             assertThatThrownBy(() -> agentDispatchService.dispatchPlan(
-                    testUser, projectId, scenarioId, "회원가입", "main"))
+                    testUser, projectId, scenarioSerial, "회원가입", "main"))
                     .isInstanceOf(CustomException.class)
                     .extracting(e -> ((CustomException) e).getErrorCode())
                     .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
@@ -271,13 +276,12 @@ class AgentDispatchServiceTest {
         void dispatchPlan_emptySteps_throwsException() {
             // given
             Long projectId = 100L;
-            Long scenarioId = 1L;
+            String scenarioSerial = "01";
 
-            ScenarioSequence seq = ScenarioSequence.builder()
-                    .projectId(projectId).scenarioSerial("01").build();
-            given(scenarioSequenceRepository.findByProjectIdAndScenarioSerialForUpdate(projectId, "01"))
+            given(scenarioSequenceRepository.findByProjectIdAndScenarioSerialForUpdate(projectId, scenarioSerial))
                     .willReturn(Optional.empty());
-            given(scenarioSequenceRepository.save(any(ScenarioSequence.class))).willReturn(seq);
+            given(scenarioSequenceRepository.save(any(ScenarioSequence.class)))
+                    .willReturn(ScenarioSequence.builder().projectId(projectId).scenarioSerial(scenarioSerial).build());
             given(testExecutionRepository.save(any(TestExecution.class))).willAnswer(invocation -> {
                 TestExecution te = invocation.getArgument(0);
                 ReflectionTestUtils.setField(te, "executionId", 1L);
@@ -288,15 +292,16 @@ class AgentDispatchServiceTest {
                     .repoUrl("https://github.com/school/repo.git").build();
             given(githubRepositoryRepository.findByProjectId(projectId)).willReturn(Optional.of(mockRepo));
 
-            Scenario mockScenario = Scenario.builder().scenarioId(scenarioId).build();
-            given(scenarioRepository.findById(scenarioId)).willReturn(Optional.of(mockScenario));
+            Scenario mockScenario = Scenario.builder().scenarioId(1L).build();
+            given(scenarioRepository.findByProjectIdAndScenarioSerial(projectId, scenarioSerial))
+                    .willReturn(Optional.of(mockScenario));
 
-            given(scenarioGuideRepository.findAllByScenarioIdOrderByStepOrder(scenarioId))
+            given(scenarioGuideRepository.findAllByScenarioIdOrderByStepOrder(1L))
                     .willReturn(List.of());
 
             // when & then
             assertThatThrownBy(() -> agentDispatchService.dispatchPlan(
-                    testUser, projectId, scenarioId, "회원가입", "main"))
+                    testUser, projectId, scenarioSerial, "회원가입", "main"))
                     .isInstanceOf(CustomException.class)
                     .extracting(e -> ((CustomException) e).getErrorCode())
                     .isEqualTo(ErrorCode.INVALID_ARGUMENT);


### PR DESCRIPTION
## 📝 PR 설명
프로젝트 생성 시 레포지토리 정보 저장 에러 및 테스트 그룹 생성 시 인자 변경

## 🛠 주요 변경 사항
- 프로젝트 생성 시 GithubRepository 테이블에 값이 저장되지 않은 에러 수정
- 테스트 그룹 생성 시 계속해서 증가하는 scenarioId 값 대신 고정된 범위의 scenarioSerial 값으로 인자 변경
- 이에 따른 테스트 코드 수정

## 🧪 테스트 체크리스트

## 📸 스크린샷 또는 비디오

## ➕ 추가 사항

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다
- [ ] 불필요한 코드를 제거했습니다
- [ ] 주석 처리를 필요한 만큼 하였습니다.
- [ ] PR 제목 또는 설명에 Jira 이슈 키를 포함했습니다

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
