### PR TITLE
[Cst-97] fix: 테스트 그룹 생성 시 발생하는 에러 해결 및 추가 API 구현

### DIFF
--- a/src/main/java/com/graduationCapstone/Probe/domain/agent/controller/AgentController.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/agent/controller/AgentController.java
@@ -52,7 +52,8 @@ public class AgentController {
                 requestDto.projectId(),
                 requestDto.scenarioSerial(),
                 requestDto.testItem(),
-                requestDto.targetBranch()
+                requestDto.targetBranch(),
+                requestDto.targetRepoId()
         );
 
         return ResponseEntity.accepted().body(Map.of("executionId", executionId));

--- a/src/main/java/com/graduationCapstone/Probe/domain/agent/dto/AgentPlanTriggerRequestDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/agent/dto/AgentPlanTriggerRequestDto.java
@@ -19,6 +19,9 @@ public record AgentPlanTriggerRequestDto(
         String testItem,        // 예: "회원가입", "로그인"
 
         @NotBlank(message = "타겟 브랜치는 필수입니다.")
-        String targetBranch
+        String targetBranch,
+
+        @NotNull(message = "타겟 레포지토리 ID는 필수입니다.")
+        Long targetRepoId
 ) {
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/agent/service/AgentDispatchService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/agent/service/AgentDispatchService.java
@@ -72,7 +72,7 @@ public class AgentDispatchService {
      */
     @Transactional
     public Long dispatchPlan(User user, Long projectId, String scenarioSerial,
-                             String testItem, String targetBranch) {
+                             String testItem, String targetBranch, Long targetRepoId) {
         log.info("Dispatching plan. ProjectId={}, Serial={}, TestItem={}", projectId, scenarioSerial, testItem);
 
         // 1. 시나리오 시리얼 조회
@@ -106,7 +106,7 @@ public class AgentDispatchService {
         log.info("TestExecution created. Id={}, ScenarioId={}", execution.getExecutionId(), execution.getTestScenarioId());
 
         // 4. 레포지토리 URL 조회
-        GithubRepository targetRepo = githubRepositoryRepository.findByProjectId(projectId)
+        GithubRepository targetRepo = githubRepositoryRepository.findByProjectIdAndGithubRepoId(projectId, targetRepoId)
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
 
         // 5. Scenario (auth_token) 조회
@@ -163,8 +163,10 @@ public class AgentDispatchService {
         // 상태 변경: TESTING (dirty checking으로 트랜잭션 커밋 시 자동 반영)
         execution.updateStatus(ExecutionStatus.TESTING);
 
+        Long targetRepoId = execution.getTestGroup().getTargetRepoId();
+
         // 레포지토리 URL 조회
-        GithubRepository targetRepo = githubRepositoryRepository.findByProjectId(execution.getProjectId())
+        GithubRepository targetRepo = githubRepositoryRepository.findByProjectIdAndGithubRepoId(execution.getProjectId(), targetRepoId)
                 .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
 
         String callbackUrl = serverUrl + "/api/agent/callback/test";

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/entity/GithubRepository.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/entity/GithubRepository.java
@@ -23,6 +23,10 @@ public class GithubRepository {
     @Column(name = "project_id", nullable = false)
     private Long projectId;
 
+    // 원본 GithubRepo 엔티티의 ID
+    @Column(name = "github_repo_id", nullable = false)
+    private Long githubRepoId;
+
     @Column(name = "repo_url", nullable = false)
     private String repoUrl;
 

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/repository/GithubRepositoryRepository.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/repository/GithubRepositoryRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface GithubRepositoryRepository extends JpaRepository<GithubRepository, Long> {
     void deleteByProjectId(Long projectId);
-    Optional<GithubRepository> findByProjectId(Long projectId);
+    Optional<GithubRepository> findByProjectIdAndGithubRepoId(Long projectId, Long githubRepoId);
 }

--- a/src/main/java/com/graduationCapstone/Probe/domain/project/service/ProjectService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/project/service/ProjectService.java
@@ -106,6 +106,7 @@ public class ProjectService {
                                     // 테스트 시스템용 github_repository 테이블 저장
                                     GithubRepository gr = GithubRepository.builder()
                                             .projectId(savedProject.getId())
+                                            .githubRepoId(repo.getId())
                                             .repoUrl("https://github.com/" + repo.getOwner() + "/" + repo.getRepoName())
                                             .visibility(repo.isPublic() ? "PUBLIC" : "PRIVATE")
                                             .starCount(repo.getStargazersCount())
@@ -520,6 +521,7 @@ public class ProjectService {
                     // 테스트 데이터 저장
                     GithubRepository gr = GithubRepository.builder()
                             .projectId(projectId)
+                            .githubRepoId(repo.getId())
                             .repoUrl("https://github.com/" + repo.getOwner() + "/" + repo.getRepoName())
                             .visibility(repo.isPublic() ? "PUBLIC" : "PRIVATE")
                             .starCount(repo.getStargazersCount())

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/controller/TestController.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/controller/TestController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 
 @Tag(name = "Test", description = "테스트 대시보드 및 결과 데이터 관리 API")
 @RestController
@@ -39,12 +40,12 @@ public class TestController {
             @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터")
     })
     @PostMapping("/setup")
-    public ResponseEntity<Void> setup(
+    public ResponseEntity<List<Long>> setup(
             @PathVariable Long projectId,
             @AuthenticationPrincipal User user,
             @Valid @RequestBody TestGroupCreateRequestDto dto) {
-        testService.createTestEntities(user, projectId, dto);
-        return ResponseEntity.ok().build();
+        List<Long> executionIds = testService.createTestEntities(user, projectId, dto);
+        return ResponseEntity.ok(executionIds);
     }
 
     @Operation(summary = "테스트 그룹명 중복 체크", description = "프로젝트 내에 동일한 테스트 그룹명이 존재하는지 확인합니다.")
@@ -209,6 +210,20 @@ public class TestController {
     }
 
     // ── 상세 조회 및 다운로드 (Details & Downloads) ──
+
+    @Operation(summary = "테스트 실행 상태 조회", description = "특정 실행 ID의 현재 상태를 조회합니다 (PLAN_GENERATING, PLAN_COMPLETED 등)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "상태 조회 성공"),
+            @ApiResponse(responseCode = "403", description = "해당 프로젝트에 속하지 않은 실행 정보 (권한 없음)"),
+            @ApiResponse(responseCode = "404", description = "실행 정보를 찾을 수 없음")
+    })
+    @GetMapping("/executions/{executionId}/status")
+    public ResponseEntity<Map<String, String>> getStatus(
+            @PathVariable Long projectId,
+            @PathVariable Long executionId) {
+        String status = testService.getExecutionStatus(projectId, executionId);
+        return ResponseEntity.ok(Map.of("status", status));
+    }
 
     @Operation(summary = "테스트 계획서 다운로드", description = "S3에 저장된 테스트 계획서(.xlsx) URL로 리다이렉트합니다.")
     @ApiResponses({@ApiResponse(responseCode = "302", description = "다운로드 URL로 이동")})

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/service/TestService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/service/TestService.java
@@ -30,7 +30,7 @@ public class TestService {
      * 시나리오가 1개여도 동일한 '그룹화' 과정을 거칩니다.
      */
     @Transactional
-    public void createTestEntities(User user, Long projectId, TestGroupCreateRequestDto dto) {
+    public List<Long> createTestEntities(User user, Long projectId, TestGroupCreateRequestDto dto) {
         if (isGroupNameDuplicate(projectId, dto.baseTestGroupName())) {
             log.warn("[DUPLICATE] 이미 존재하는 그룹명입니다: {}", dto.baseTestGroupName());
             throw new CustomException(ErrorCode.DUPLICATE_TESTGROUP_NAME);
@@ -45,6 +45,8 @@ public class TestService {
                 .targetRepoId(dto.targetRepoId())
                 .targetBranch(dto.targetBranch())
                 .build());
+
+        List<Long> executionIds = new java.util.ArrayList<>();
 
         // 선택된 시나리오 리스트를 순회하며 에이전트에게 생성/발송을 요청합니다.
         for (String serial : dto.scenarioSerials()) {
@@ -68,10 +70,29 @@ public class TestService {
             // 테스트 그룹 엔티티와 그룹명 스냅샷을 강제로 주입하여 교정합니다.
             execution.updateGroupAndName(group, group.getGroupName());
 
+            executionIds.add(executionId);
+
             log.info("[FLOW] 에이전트 요청 완료 및 후처리 성공 - ExecutionID: {}, Scenario: {}",
                     executionId, serialInfo.getTestItem());
         }
         log.info("[FLOW] 모든 시나리오에 대한 그룹 테스트 요청 완료");
+        return executionIds;
+    }
+
+    /**
+     * 테스트 계획서/실행 상태 조회
+     */
+    @Transactional(readOnly = true)
+    public String getExecutionStatus(Long projectId, Long executionId) {
+        TestExecution execution = executionRepo.findById(executionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        if (!execution.getProjectId().equals(projectId)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        // status Enum의 name을 반환 (PLAN_GENERATING, PLAN_COMPLETED 등)
+        return execution.getStatus().name();
     }
 
     /**

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/service/TestService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/service/TestService.java
@@ -31,6 +31,11 @@ public class TestService {
      */
     @Transactional
     public void createTestEntities(User user, Long projectId, TestGroupCreateRequestDto dto) {
+        if (isGroupNameDuplicate(projectId, dto.baseTestGroupName())) {
+            log.warn("[DUPLICATE] 이미 존재하는 그룹명입니다: {}", dto.baseTestGroupName());
+            throw new CustomException(ErrorCode.DUPLICATE_TESTGROUP_NAME);
+        }
+
         log.info("[FLOW] 테스트 그룹 생성 및 실행 시작 - ProjectID: {}, Group: {}", projectId, dto.baseTestGroupName());
 
         // 사용자가 입력한 그룹명으로 TestGroup을 먼저 저장합니다.

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/service/TestService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/service/TestService.java
@@ -52,7 +52,8 @@ public class TestService {
                     projectId,
                     serial,
                     serialInfo.getTestItem(),
-                    dto.targetBranch()
+                    dto.targetBranch(),
+                    dto.targetRepoId()
             );
 
             // 에이전트가 만든 실행 엔티티를 찾아 그룹과 이름을 동기화합니다.

--- a/src/main/java/com/graduationCapstone/Probe/global/exception/ErrorCode.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/exception/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
     // 409 CONFLICT (데이터 충돌)
     DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "RESOURCE40901", "데이터 무결성 제약 조건(예: 중복 값)을 위반했습니다."),
     DUPLICATE_PROJECT_NAME(HttpStatus.CONFLICT, "PROJ40901", "이미 동일한 이름의 프로젝트를 보유하고 있습니다."),
+    DUPLICATE_TESTGROUP_NAME(HttpStatus.CONFLICT, "TESTGROUP40901", "이미 동일한 이름의 테스트 그룹을 보유하고 있습니다."),
 
     // 500 INTERNAL SERVER ERROR (서버 내부 오류)
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER50001", "서버 내부 오류가 발생했습니다."),

--- a/src/main/java/com/graduationCapstone/Probe/global/init/GuideInitializer.java
+++ b/src/main/java/com/graduationCapstone/Probe/global/init/GuideInitializer.java
@@ -20,6 +20,11 @@ public class GuideInitializer implements ApplicationRunner {
     @Override
     @Transactional
     public void run(ApplicationArguments args) {
+        if (guideRepository.count() > 0) {
+            log.info("가이드 데이터가 이미 존재하여 초기화를 건너뜁니다.");
+            return;
+        }
+
         log.info("Enum 기반 Guide 마스터 데이터 동기화 시작...");
 
         for (ScenarioSerial serial : ScenarioSerial.values()) {

--- a/src/test/java/com/graduationCapstone/Probe/domain/agent/service/AgentDispatchServiceTest.java
+++ b/src/test/java/com/graduationCapstone/Probe/domain/agent/service/AgentDispatchServiceTest.java
@@ -10,6 +10,7 @@ import com.graduationCapstone.Probe.domain.project.repository.ScenarioRepository
 import com.graduationCapstone.Probe.domain.test.entity.ExecutionStatus;
 import com.graduationCapstone.Probe.domain.test.entity.ScenarioSequence;
 import com.graduationCapstone.Probe.domain.test.entity.TestExecution;
+import com.graduationCapstone.Probe.domain.test.entity.TestGroup;
 import com.graduationCapstone.Probe.domain.test.repository.ScenarioSequenceRepository;
 import com.graduationCapstone.Probe.domain.test.repository.TestExecutionRepository;
 import com.graduationCapstone.Probe.domain.user.entity.User;
@@ -110,6 +111,7 @@ class AgentDispatchServiceTest {
             String scenarioSerial = "01";
             String testItem = "회원가입";
             String targetBranch = "feature/login";
+            Long targetRepoId = 2L;
 
             // ScenarioSequence가 없는 경우 → 새로 생성
             given(scenarioSequenceRepository.findByProjectIdAndScenarioSerialForUpdate(projectId, "01"))
@@ -131,7 +133,8 @@ class AgentDispatchServiceTest {
             GithubRepository mockRepo = GithubRepository.builder()
                     .repoUrl("https://github.com/school/target-repo.git")
                     .build();
-            given(githubRepositoryRepository.findByProjectId(projectId)).willReturn(Optional.of(mockRepo));
+            given(githubRepositoryRepository.findByProjectIdAndGithubRepoId(projectId, targetRepoId))
+                    .willReturn(Optional.of(mockRepo));
 
             Scenario mockScenario = Scenario.builder()
                     .scenarioId(1L)
@@ -151,7 +154,7 @@ class AgentDispatchServiceTest {
 
             // when
             Long executionId = agentDispatchService.dispatchPlan(
-                    testUser, projectId, scenarioSerial, testItem, targetBranch);
+                    testUser, projectId, scenarioSerial, testItem, targetBranch, targetRepoId);
 
             // then — TestExecution 생성 확인
             ArgumentCaptor<TestExecution> executionCaptor = ArgumentCaptor.forClass(TestExecution.class);
@@ -190,6 +193,7 @@ class AgentDispatchServiceTest {
             // given
             Long projectId = 100L;
             String scenarioSerial = "01";
+            Long targetRepoId = 2L;
 
             ScenarioSequence existingSequence = ScenarioSequence.builder()
                     .projectId(projectId)
@@ -209,7 +213,7 @@ class AgentDispatchServiceTest {
             GithubRepository mockRepo = GithubRepository.builder()
                     .repoUrl("https://github.com/school/repo.git")
                     .build();
-            given(githubRepositoryRepository.findByProjectId(projectId)).willReturn(Optional.of(mockRepo));
+            given(githubRepositoryRepository.findByProjectIdAndGithubRepoId(projectId,targetRepoId)).willReturn(Optional.of(mockRepo));
 
             Scenario mockScenario = Scenario.builder().scenarioId(1L).build();
             given(scenarioRepository.findByProjectIdAndScenarioSerial(projectId, scenarioSerial)).willReturn(Optional.of(mockScenario));
@@ -222,7 +226,7 @@ class AgentDispatchServiceTest {
             mockWebServer.enqueue(new MockResponse().setResponseCode(202));
 
             // when
-            agentDispatchService.dispatchPlan(testUser, projectId, scenarioSerial, "회원가입", "main");
+            agentDispatchService.dispatchPlan(testUser, projectId, scenarioSerial, "회원가입", "main", targetRepoId);
 
             // then — attempt가 4로 증가
             ArgumentCaptor<TestExecution> captor = ArgumentCaptor.forClass(TestExecution.class);
@@ -236,7 +240,7 @@ class AgentDispatchServiceTest {
         void dispatchPlan_unknownTestItem_throwsException() {
             // when & then
             assertThatThrownBy(() -> agentDispatchService.dispatchPlan(
-                    testUser, 100L, "01", "존재하지 않는 시나리오", "main"))
+                    testUser, 100L, "01", "존재하지 않는 시나리오", "main", 2L))
                     .isInstanceOf(IllegalArgumentException.class);
         }
 
@@ -246,6 +250,7 @@ class AgentDispatchServiceTest {
             // given
             Long projectId = 100L;
             String scenarioSerial = "01";
+            Long targetRepoId = 2L;
 
             given(scenarioSequenceRepository.findByProjectIdAndScenarioSerialForUpdate(projectId, scenarioSerial))
                     .willReturn(Optional.empty());
@@ -261,11 +266,11 @@ class AgentDispatchServiceTest {
                 ReflectionTestUtils.setField(te, "executionId", 1L);
                 return te;
             });
-            given(githubRepositoryRepository.findByProjectId(projectId)).willReturn(Optional.empty());
+            given(githubRepositoryRepository.findByProjectIdAndGithubRepoId(projectId, targetRepoId)).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> agentDispatchService.dispatchPlan(
-                    testUser, projectId, scenarioSerial, "회원가입", "main"))
+                    testUser, projectId, scenarioSerial, "회원가입", "main", targetRepoId))
                     .isInstanceOf(CustomException.class)
                     .extracting(e -> ((CustomException) e).getErrorCode())
                     .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
@@ -277,6 +282,7 @@ class AgentDispatchServiceTest {
             // given
             Long projectId = 100L;
             String scenarioSerial = "01";
+            Long targetRepoId = 2L;
 
             given(scenarioSequenceRepository.findByProjectIdAndScenarioSerialForUpdate(projectId, scenarioSerial))
                     .willReturn(Optional.empty());
@@ -290,7 +296,7 @@ class AgentDispatchServiceTest {
 
             GithubRepository mockRepo = GithubRepository.builder()
                     .repoUrl("https://github.com/school/repo.git").build();
-            given(githubRepositoryRepository.findByProjectId(projectId)).willReturn(Optional.of(mockRepo));
+            given(githubRepositoryRepository.findByProjectIdAndGithubRepoId(projectId,targetRepoId)).willReturn(Optional.of(mockRepo));
 
             Scenario mockScenario = Scenario.builder().scenarioId(1L).build();
             given(scenarioRepository.findByProjectIdAndScenarioSerial(projectId, scenarioSerial))
@@ -301,7 +307,7 @@ class AgentDispatchServiceTest {
 
             // when & then
             assertThatThrownBy(() -> agentDispatchService.dispatchPlan(
-                    testUser, projectId, scenarioSerial, "회원가입", "main"))
+                    testUser, projectId, scenarioSerial, "회원가입", "main", targetRepoId))
                     .isInstanceOf(CustomException.class)
                     .extracting(e -> ((CustomException) e).getErrorCode())
                     .isEqualTo(ErrorCode.INVALID_ARGUMENT);
@@ -320,8 +326,14 @@ class AgentDispatchServiceTest {
         void dispatchTest_success() throws InterruptedException {
             // given
             Long executionId = 1L;
+            Long projectId = 100L;
+            Long targetRepoId = 2L;
             User tester = User.builder()
                     .id(1L).githubId("12345").username("tester").email("tester@test.com").build();
+
+            TestGroup mockGroup = TestGroup.builder()
+                    .targetRepoId(targetRepoId)
+                    .build();
 
             TestExecution execution = TestExecution.builder()
                     .executionId(executionId)
@@ -333,11 +345,14 @@ class AgentDispatchServiceTest {
                     .testName("회원가입")
                     .status(ExecutionStatus.PLAN_COMPLETED)
                     .build();
+
+            ReflectionTestUtils.setField(execution, "testGroup", mockGroup);
+
             given(testExecutionRepository.findActiveById(executionId)).willReturn(Optional.of(execution));
 
             GithubRepository mockRepo = GithubRepository.builder()
                     .repoUrl("https://github.com/school/target-repo.git").build();
-            given(githubRepositoryRepository.findByProjectId(100L)).willReturn(Optional.of(mockRepo));
+            given(githubRepositoryRepository.findByProjectIdAndGithubRepoId(projectId, targetRepoId)).willReturn(Optional.of(mockRepo));
 
             mockWebServer.enqueue(new MockResponse().setResponseCode(202));
 


### PR DESCRIPTION
## 📝 PR 설명
테스트 그룹 생성 시 발생하는 에러 해결 및 추가 API 구현

## 🛠 주요 변경 사항
- GithubRepository 엔티티에 githubRepoId 추가 및 복합키 조회 로직 적용하여 테스트 그룹 생성 시 발생하는 IncorrectResultSizeDataAccessException(500 에러) 해결
- 테스트 그룹 생성 시 중복체크 로직 보완
- 서버 재실행 시 시나리오 데이터 중복 저장 에러 방지를 위해 시나리오 데이터 초기화 건너뛰기 로직 추가
- 테스트 그룹 생성 시 executionId 반환값 전달되도록 수정
- 테스트 실행 상태 조회 API 구현
- AgentDispatchService 관련 테스트 코드 수정

## 🧪 테스트 체크리스트


## 📸 스크린샷 또는 비디오


## ➕ 추가 사항


## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다
- [ ] 불필요한 코드를 제거했습니다
- [ ] 주석 처리를 필요한 만큼 하였습니다.
- [ ] PR 제목 또는 설명에 Jira 이슈 키를 포함했습니다

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
