### PR TITLE
[CST-97] fix: testCodeName, testGroupName 반환 위치 정정

### DIFF
--- a/src/main/java/com/graduationCapstone/Probe/domain/test/controller/TestController.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/controller/TestController.java
@@ -177,7 +177,7 @@ public class TestController {
         return ResponseEntity.ok(TestGroupResponseDto.from(g));
     }
 
-    @Operation(summary = "프로젝트 내 테스트 그룹 관련 정보(ID, 테스트코드명, Pass 비율, 테스트 시간, 테스터, 일시) 조회 및 정렬 (필드 선택 가능)", description = "field를 입력하지 않으면 기본값(id)으로 정렬됩니다.")
+    @Operation(summary = "프로젝트 내 테스트 그룹 관련 정보(ID, 테스트그룹명, Pass 비율, 테스트 시간, 테스터, 일시) 조회 및 정렬 (필드 선택 가능)", description = "field를 입력하지 않으면 기본값(id)으로 정렬됩니다.")
     @GetMapping("/list/basic") // 쿼리 파라미터 사용
     public ResponseEntity<List<TestExecutionListDto>> getBasicListOptional(
             @PathVariable Long projectId,
@@ -186,7 +186,7 @@ public class TestController {
         return ResponseEntity.ok(testService.getBasicSortedList(projectId, field, asc));
     }
 
-    @Operation(summary = "테스트 결과 관련 정보(ID, 테스트명, 상태, 테스트 시간, 테스터, 일시) 조회 및 정렬 (필드 선택 가능)",
+    @Operation(summary = "테스트 결과 관련 정보(ID, 테스트코드명, 상태, 테스트 시간, 테스터, 일시) 조회 및 정렬 (필드 선택 가능)",
             description = "field 미입력 시 기본값(id)으로 정렬됩니다.")
     @ApiResponses({@ApiResponse(responseCode = "200", description = "요약 목록 조회 성공")})
     @GetMapping("/list/summary") // 쿼리 파라미터 사용

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestCaseSummaryDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestCaseSummaryDto.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 public record TestCaseSummaryDto(
         Long resultId,
         String testCaseId,
-        String testGroupName,
+        String testCodeName,
         String status,
         String duration,
         String tester,

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestExecutionListDto.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/dto/TestExecutionListDto.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 public record TestExecutionListDto(
         Long groupId,
         String testCaseId,
-        String testCodeName,
+        String testGroupName,
         String passRatio,
         String duration,
         String tester,

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/service/TestService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/service/TestService.java
@@ -142,7 +142,7 @@ public class TestService {
 
     /**
      * [Basic 목록] 프로젝트 내 테스트 그룹 요약 정보 조회
-     * 반환 규격: groupId, testCaseId, testCodeName, passRatio, duration, tester, testerProfileImage, completedAt
+     * 반환 규격: groupId, testCaseId, testGroupName, passRatio, duration, tester, testerProfileImage, completedAt
      */
     @Transactional(readOnly = true)
     public List<TestExecutionListDto> getBasicSortedList(Long projectId, String field, boolean ascending) {
@@ -163,7 +163,7 @@ public class TestService {
                     return new TestExecutionListDto(
                             e.getTestGroup() != null ? e.getTestGroup().getGroupId() : null,
                             e.getTestScenarioId(),
-                            e.getTestName(),
+                            e.getTestGroup() != null ? e.getTestGroup().getGroupName() : e.getTestName(),
                             calculateRatio(pass, total),
                             formatDuration(e.getDurationSeconds()),
                             e.getTesterName(),
@@ -175,7 +175,7 @@ public class TestService {
 
     /**
      * [Summary 목록] 테스트 결과 상세 목록 조회
-     * 반환 규격: resultId, testCaseId, testGroupName, status, duration, tester, testerProfileImage, completedAt
+     * 반환 규격: resultId, testCaseId, testCodeName, status, duration, tester, testerProfileImage, completedAt
      */
     @Transactional(readOnly = true)
     public List<TestCaseSummaryDto> getTestSummaryList(Long projectId, String sortField, boolean ascending) {
@@ -189,7 +189,7 @@ public class TestService {
                         .map(res -> new TestCaseSummaryDto(
                                 res.getResultId(),
                                 res.getFullTestCaseId(),
-                                exec.getTestGroup() != null ? exec.getTestGroup().getGroupName() : exec.getTestName(),
+                                res.getTestCodeName(),
                                 res.getStatus().name(),
                                 formatDuration(res.getDurationSeconds()),
                                 exec.getTesterName(),


### PR DESCRIPTION
## 📝 PR 설명
/api/projects/{projectId}/tests/list/basic 및 /api/projects/{projectId}/tests/list/summary API 요청 시 testCodeName, testGroupName가 반대로 출력되는 상황 수정

## 🛠 주요 변경 사항

## 🧪 테스트 체크리스트

## 📸 스크린샷 또는 비디오

## ➕ 추가 사항

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다
- [ ] 불필요한 코드를 제거했습니다
- [ ] 주석 처리를 필요한 만큼 하였습니다.
- [ ] PR 제목 또는 설명에 Jira 이슈 키를 포함했습니다

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
