### PR TITLE
[CST-97] fix: AiTestRequest 파일 형식 record -> class 로 변경(Jackson 매핑 안정성 확보)

### DIFF
--- a/src/main/java/com/graduationCapstone/Probe/infrastructure/ai/dto/AiTestRequest.java
+++ b/src/main/java/com/graduationCapstone/Probe/infrastructure/ai/dto/AiTestRequest.java
@@ -15,26 +15,26 @@ import lombok.NoArgsConstructor;
 public class AiTestRequest {
 
         @JsonProperty("execution_id")
-        private Long executionId;
+        Long executionId;
 
         @JsonProperty("repository_url")
-        private String repositoryUrl;
+        String repositoryUrl;
 
         @JsonProperty("target_branch")
-        private String targetBranch;
+        String targetBranch;
 
         @JsonProperty("requirement")
-        private String requirement;
+        String requirement;
 
         @JsonProperty("auth_token")
-        private String authToken;
+        String authToken;
 
         @JsonProperty("callback_url")
-        private String callbackUrl;
+        String callbackUrl;
 
         @JsonProperty("scenario_serial")
-        private String scenarioSerial;
+        String scenarioSerial;
 
         @JsonProperty("scenario_attempt")
-        private String scenarioAttempt;
+        String scenarioAttempt;
 }

--- a/src/main/java/com/graduationCapstone/Probe/infrastructure/ai/dto/AiTestRequest.java
+++ b/src/main/java/com/graduationCapstone/Probe/infrastructure/ai/dto/AiTestRequest.java
@@ -20,8 +20,8 @@ public class AiTestRequest {
         @JsonProperty("repository_url")
         private String repositoryUrl;
 
-        @JsonProperty("branch")
-        private String branch;
+        @JsonProperty("target_branch")
+        private String targetBranch;
 
         @JsonProperty("requirement")
         private String requirement;

--- a/src/main/java/com/graduationCapstone/Probe/infrastructure/ai/dto/AiTestRequest.java
+++ b/src/main/java/com/graduationCapstone/Probe/infrastructure/ai/dto/AiTestRequest.java
@@ -1,34 +1,40 @@
 package com.graduationCapstone.Probe.infrastructure.ai.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * AI 서버로 테스트 생성/실행을 요청할 때 사용하는 DTO.
+ * record에서 일반 class로 변경하여 Jackson 매핑 안정성 확보
  */
-public record AiTestRequest(
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiTestRequest {
 
         @JsonProperty("execution_id")
-        Long executionId,
+        private Long executionId;
 
         @JsonProperty("repository_url")
-        String repositoryUrl,
+        private String repositoryUrl;
 
         @JsonProperty("branch")
-        String branch,
+        private String branch;
 
         @JsonProperty("requirement")
-        String requirement,
+        private String requirement;
 
         @JsonProperty("auth_token")
-        String authToken,
+        private String authToken;
 
         @JsonProperty("callback_url")
-        String callbackUrl,
+        private String callbackUrl;
 
         @JsonProperty("scenario_serial")
-        String scenarioSerial,
+        private String scenarioSerial;
 
         @JsonProperty("scenario_attempt")
-        String scenarioAttempt
-) {
+        private String scenarioAttempt;
 }


### PR DESCRIPTION
## 📝 PR 설명
Record 타입이 JsonProperty를 무시하고 원래의 변수명으로 AI 서버에 전송하는 상황 예방하기 위해 AiTestRequest.java를 일반 class로 변경하였습니다.

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다
- [ ] 불필요한 코드를 제거했습니다
- [ ] 주석 처리를 필요한 만큼 하였습니다.
- [ ] PR 제목 또는 설명에 Jira 이슈 키를 포함했습니다

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
