### PR TITLE
[CST-97] fix: ScenarioDetailData 파싱 에러 해결

### DIFF
--- a/src/main/java/com/graduationCapstone/Probe/domain/agent/service/AgentCallbackService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/agent/service/AgentCallbackService.java
@@ -94,18 +94,44 @@ public class AgentCallbackService {
         // 개별 TestResult 저장
         if (dto.results() != null && !dto.results().isEmpty()) {
             List<TestResult> results = dto.results().stream()
-                    .map(r -> TestResult.builder()
-                            .testExecution(execution)
-                            .testCaseNumber(r.testCaseNumber())
-                            .caseName(r.caseName())
-                            .testCodeName(r.testCodeName())
-                            .status(r.status())
-                            .durationSeconds(r.durationSeconds())
-                            .errorLog(r.errorLog())
-                            .testCode(r.testCode())
-                            .scenarioDetail(r.scenarioDetail())
-                            .screenshotS3Urls(r.screenshotS3Urls())
-                            .build())
+                    .map(r -> {
+                        // [시리얼 제거] "TXXXX_XX - "시리얼을 제외한 이름만 추출
+                        String rawCodeName = r.testCodeName();
+                        String cleanCodeName = rawCodeName;
+                        if (rawCodeName != null) {
+                            cleanCodeName = rawCodeName.replaceAll("^T\\d{4}_\\d{2}\\s*-\\s*", "");
+                        }
+
+                        // ScenarioDetailData 파싱
+                        com.graduationCapstone.Probe.domain.test.entity.ScenarioDetailData embeddedDetail = null;
+                        if (r.scenarioDetail() != null) {
+                            var sd = r.scenarioDetail();
+                            embeddedDetail = new com.graduationCapstone.Probe.domain.test.entity.ScenarioDetailData(
+                                    sd.scenarioName(),     // 테스트 시나리오명
+                                    sd.description(),      // 설명
+                                    sd.testCaseId(),       // 테스트 케이스 ID
+                                    r.caseName(),          // 테스트 케이스명 (대시보드 목록의 caseName 매핑)
+                                    sd.precondition(),     // 전제 조건
+                                    sd.testData(),         // 테스트 데이터
+                                    sd.executionSteps(),   // 실행 단계
+                                    sd.result()            // 결과
+                            );
+                        }
+
+                        // TestResult 엔티티 객체 생성 및 정제된 값 주입
+                        return TestResult.builder()
+                                .testExecution(execution)
+                                .testCaseNumber(r.testCaseNumber())
+                                .caseName(r.caseName())
+                                .testCodeName(cleanCodeName) // 정제된 이름 저장
+                                .status(r.status())
+                                .durationSeconds(r.durationSeconds())
+                                .errorLog(r.errorLog())
+                                .testCode(r.testCode())
+                                .scenarioDetail(embeddedDetail) // 바인딩된 객체 주입
+                                .screenshotS3Urls(r.screenshotS3Urls())
+                                .build();
+                    })
                     .toList();
 
             testResultRepository.saveAll(results);

--- a/src/main/java/com/graduationCapstone/Probe/domain/test/service/TestService.java
+++ b/src/main/java/com/graduationCapstone/Probe/domain/test/service/TestService.java
@@ -190,7 +190,7 @@ public class TestService {
                         .map(res -> new TestCaseSummaryDto(
                                 res.getResultId(),
                                 res.getFullTestCaseId(),
-                                res.getCaseName(),
+                                res.getTestCodeName(),
                                 res.getStatus().name(),
                                 formatDuration(res.getDurationSeconds()),
                                 exec.getTesterName(),


### PR DESCRIPTION
## 📝 PR 설명
AI서버에서 받은 ScenarioDetailData에 대한 파싱 로직 추가


## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다
- [ ] 불필요한 코드를 제거했습니다
- [ ] 주석 처리를 필요한 만큼 하였습니다.
- [ ] PR 제목 또는 설명에 Jira 이슈 키를 포함했습니다

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
